### PR TITLE
Disable hover when DatePicker does not have focus

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,8 @@
 {
   "presets": ["airbnb"],
+  "plugins": [
+    ["transform-replace-object-assign", "object.assign"],
+  ],
   "env": {
     "test": {
       "plugins": ["istanbul"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v10.2.0
+- [new] Add RTL support to the DRP and the SDP with the `isRTL` prop ([#454](https://github.com/airbnb/react-dates/pull/454))
+- [new] Add `renderMonth` prop to DRP and SDP([#449](https://github.com/airbnb/react-dates/pull/449))
+
 ## v10.1.2
 - [fix] Remove unused scss variables ([#475](https://github.com/airbnb/react-dates/pull/475))
 - [fix] Address some issues introduced by the accessibility PR in v10.0.0 ([#477](https://github.com/airbnb/react-dates/pull/477))
@@ -9,13 +13,13 @@
 - [fix] Remove unnecessary `onClose` instances on the `SDPInput` and `DateInput` components
 
 ## v10.1.0
-- [new] Adds `onClose` callback ([#397](https://github.com/airbnb/react-dates/pull/397))
+- [new] Add `onClose` callback ([#397](https://github.com/airbnb/react-dates/pull/397))
 
 ## v10.0.1
 - [fix] Fix a few nits as a result of the accessibility PR ([#429](https://github.com/airbnb/react-dates/pull/429))
 
 ## v10.0.0
-- [breaking] Added keyboard accessibility to react-dates ([#301](https://github.com/airbnb/react-dates/pull/301))
+- [breaking] Add keyboard accessibility to react-dates ([#301](https://github.com/airbnb/react-dates/pull/301))
 
 ## v9.0.1
 - [fix] Fixes `withPortal` implementation in Firefox ([#421](https://github.com/airbnb/react-dates/pull/421))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## v11.0.0
+- [breaking] Dramatic rearchitecture of modifiers with the goal of improved performance ([#450](https://github.com/airbnb/react-dates/pull/450))
+
 ## v10.2.0
 - [new] Add RTL support to the DRP and the SDP with the `isRTL` prop ([#454](https://github.com/airbnb/react-dates/pull/454))
 - [new] Add `renderMonth` prop to DRP and SDP([#449](https://github.com/airbnb/react-dates/pull/449))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v10.1.2
+- [fix] Remove unused scss variables ([#475](https://github.com/airbnb/react-dates/pull/475))
+- [fix] Address some issues introduced by the accessibility PR in v10.0.0 ([#477](https://github.com/airbnb/react-dates/pull/477))
+- [fix] Only update phrase object in the DRP when necessary ([#448](https://github.com/airbnb/react-dates/pull/448))
+
 ## v10.1.1
 - [fix] Remove unnecessary `onClose` instances on the `SDPInput` and `DateInput` components
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ react-dates comes with a set of SCSS variables that can be overridden to add you
 ```scss
 //overriding default sass variables with my project's colors
 $react-dates-color-primary: $some-color-specific-to-my-project;
-$react-dates-color-primary-dark: $some-other-color-specific-to-my-project;
+$react-dates-color-secondary: $some-other-color-specific-to-my-project;
 @import '~react-dates/css/variables.scss';
 @import '~react-dates/css/styles.scss';
 ```

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ numberOfMonths: PropTypes.number,
 keepOpenOnDateSelect: PropTypes.bool,
 reopenPickerOnClearDates: PropTypes.bool,
 renderCalendarInfo: PropTypes.func,
+isRTL: PropTypes.bool,
 
 // navigation related props
 navPrev: PropTypes.node,
@@ -166,6 +167,7 @@ numberOfMonths: PropTypes.number,
 keepOpenOnDateSelect: PropTypes.bool,
 reopenPickerOnClearDate: PropTypes.bool,
 renderCalendarInfo: PropTypes.func,
+isRTL: PropTypes.bool,
 
 // navigation related props
 navPrev: PropTypes.node,

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ numberOfMonths: PropTypes.number,
 keepOpenOnDateSelect: PropTypes.bool,
 reopenPickerOnClearDates: PropTypes.bool,
 renderCalendarInfo: PropTypes.func,
+hideKeyboardShortcutsPanel: PropTypes.bool,
 isRTL: PropTypes.bool,
 
 // navigation related props
@@ -167,6 +168,7 @@ numberOfMonths: PropTypes.number,
 keepOpenOnDateSelect: PropTypes.bool,
 reopenPickerOnClearDate: PropTypes.bool,
 renderCalendarInfo: PropTypes.func,
+hideKeyboardShortcutsPanel: PropTypes.bool,
 isRTL: PropTypes.bool,
 
 // navigation related props

--- a/constants.js
+++ b/constants.js
@@ -1,6 +1,7 @@
 module.exports = {
   DISPLAY_FORMAT: 'L',
   ISO_FORMAT: 'YYYY-MM-DD',
+  ISO_MONTH_FORMAT: 'YYYY-MM',
 
   START_DATE: 'startDate',
   END_DATE: 'endDate',

--- a/css/CalendarMonth.scss
+++ b/css/CalendarMonth.scss
@@ -7,7 +7,7 @@
 
   &:first-of-type {
     position: absolute;
-    z-index: -1;
+    z-index: $react-dates-z-index - 1;
     opacity: 0;
     pointer-events: none;
   }

--- a/css/CalendarMonthGrid.scss
+++ b/css/CalendarMonthGrid.scss
@@ -2,7 +2,7 @@
 
 .CalendarMonthGrid {
   background: $react-dates-color-white;
-  z-index: 0;
+  z-index: $react-dates-z-index;
   text-align: left;
 }
 
@@ -10,7 +10,7 @@
   -webkit-transition: -webkit-transform 0.2s ease-in-out;
   -moz-transition: -moz-transform 0.2s ease-in-out;
   transition: transform 0.2s ease-in-out;
-  z-index: 1;
+  z-index: $react-dates-z-index + 1;
 }
 
 .CalendarMonthGrid--horizontal {

--- a/css/DateInput.scss
+++ b/css/DateInput.scss
@@ -25,7 +25,7 @@ $caret-top: $react-dates-spacing-vertical-picker - $react-dates-width-tooltip-ar
   border: $react-dates-width-tooltip-arrow / 2 solid transparent;
   border-top: 0;
   left: 22px;
-  z-index: 2;
+  z-index: $react-dates-z-index + 2;
 }
 
 .DateInput--with-caret::before {

--- a/css/DateRangePicker.scss
+++ b/css/DateRangePicker.scss
@@ -23,6 +23,10 @@
   top: $react-dates-spacing-vertical-picker;
 }
 
+.DateRangePicker__picker--rtl {    
+  direction: rtl;
+}
+
 .DateRangePicker__picker--direction-left {
   left: 0;
 }

--- a/css/DateRangePicker.scss
+++ b/css/DateRangePicker.scss
@@ -17,7 +17,7 @@
 }
 
 .DateRangePicker__picker {
-  z-index: 1;
+  z-index: $react-dates-z-index + 1;
   background-color: $react-dates-color-white;
   position: absolute;
   top: $react-dates-spacing-vertical-picker;
@@ -58,7 +58,7 @@
   top: 0;
   right: 0;
   padding: 15px;
-  z-index: 2;
+  z-index: $react-dates-z-index + 2;
 
   svg {
     height: 15px;

--- a/css/DateRangePickerInput.scss
+++ b/css/DateRangePickerInput.scss
@@ -10,6 +10,10 @@
   background: $react-dates-color-gray-lighter;
 }
 
+.DateRangePickerInput--rtl {
+  direction: rtl;
+}
+
 .DateRangePickerInput__arrow {
   display: inline-block;
   vertical-align: middle;

--- a/css/DayPicker.scss
+++ b/css/DayPicker.scss
@@ -40,7 +40,7 @@
   color: $react-dates-color-placeholder-text;
   position: absolute;
   top: 62px;
-  z-index: 2;
+  z-index: $react-dates-z-index + 2;
   padding: 0 13px;
   text-align: left;
 

--- a/css/DayPicker.scss
+++ b/css/DayPicker.scss
@@ -48,17 +48,12 @@
     list-style: none;
     margin: 1px 0;
     padding-left: 0;
+    padding-right: 0;
   }
 
   li {
     display: inline-block;
     text-align: center;
-  }
-}
-
-.DayPicker__week-header--rtl {
-  ul {
-    padding-right: 0;
   }
 }
 

--- a/css/DayPicker.scss
+++ b/css/DayPicker.scss
@@ -56,6 +56,12 @@
   }
 }
 
+.DayPicker__week-header--rtl {
+  ul {
+    padding-right: 0;
+  }
+}
+
 .DayPicker--vertical .DayPicker__week-header {
   left: 50%;
 }

--- a/css/DayPickerKeyboardShortcuts.scss
+++ b/css/DayPickerKeyboardShortcuts.scss
@@ -17,10 +17,11 @@
 .DayPickerKeyboardShortcuts__show {
   width: 22px;
   position: absolute;
+  z-index: $react-dates-z-index + 2;
 }
 
 .DayPickerKeyboardShortcuts__show--bottom-right {
-  border-top: 26px solid $react-dates-color-white;
+  border-top: 26px solid transparent;
   border-right: 33px solid $react-dates-color-primary;
   bottom: 0;
   right: 0;
@@ -36,7 +37,7 @@
 }
 
 .DayPickerKeyboardShortcuts__show--top-right {
-  border-bottom: 26px solid $react-dates-color-white;
+  border-bottom: 26px solid transparent;
   border-right: 33px solid $react-dates-color-primary;
   top: 0;
   right: 0;
@@ -52,7 +53,7 @@
 }
 
 .DayPickerKeyboardShortcuts__show--top-left {
-  border-bottom: 26px solid $react-dates-color-white;
+  border-bottom: 26px solid transparent;
   border-left: 33px solid $react-dates-color-primary;
   top: 0;
   left: 0;
@@ -73,6 +74,7 @@
 }
 
 .DayPickerKeyboardShortcuts__panel {
+  overflow: auto;
   background: $react-dates-color-white;
   border: 1px solid $react-dates-color-border;
   border-radius: 2px;
@@ -81,7 +83,7 @@
   bottom: 0;
   right: 0;
   left: 0;
-  z-index: 2;
+  z-index: $react-dates-z-index + 2;
   padding: 22px;
   margin: 33px;
 }
@@ -102,7 +104,7 @@
   position: absolute;
   right: 22px;
   top: 22px;
-  z-index: 2;
+  z-index: $react-dates-z-index + 2;
 
   svg {
     height: 15px;
@@ -126,7 +128,6 @@
 
 .KeyboardShortcutRow__key-container {
   display: inline-block;
-  width: 15%;
   white-space: nowrap;
   text-align: right;
   margin-right: 6px;
@@ -141,7 +142,9 @@
 }
 
 .KeyboardShortcutRow__action {
-  display: inline-block;
+  display: inline;
+  word-break: break-word;
+  margin-left: 8px;
 }
 
 .DayPickerKeyboardShortcuts__panel--block {

--- a/css/DayPickerNavigation.scss
+++ b/css/DayPickerNavigation.scss
@@ -34,7 +34,7 @@
     border-radius: 3px;
     padding: 6px 9px;
     top: 18px;
-    z-index: 2;
+    z-index: $react-dates-z-index + 2;
     position: absolute;
   }
 
@@ -64,7 +64,7 @@
   left: 0;
   height: 52px;
   width: 100%;
-  z-index: 2;
+  z-index: $react-dates-z-index + 2;
 
   .DayPickerNavigation__prev,
   .DayPickerNavigation__next {

--- a/css/DayPickerNavigation.scss
+++ b/css/DayPickerNavigation.scss
@@ -42,8 +42,18 @@
     left: 22px;
   }
 
+  .DayPickerNavigation__prev--rtl {  
+    left: auto;
+    right: 22px;
+  }
+
   .DayPickerNavigation__next {
     right: 22px;
+  }
+
+  .DayPickerNavigation__next--rtl {  
+    right: auto;
+    left: 22px;
   }
 
   .DayPickerNavigation__prev--default,

--- a/css/SingleDatePicker.scss
+++ b/css/SingleDatePicker.scss
@@ -12,7 +12,7 @@
   top: $react-dates-spacing-vertical-picker;
 }
 
-.SingleDatePicker__picker--rtl{
+.SingleDatePicker__picker--rtl {
   direction: rtl;
 }
 

--- a/css/SingleDatePicker.scss
+++ b/css/SingleDatePicker.scss
@@ -12,6 +12,10 @@
   top: $react-dates-spacing-vertical-picker;
 }
 
+.SingleDatePicker__picker--rtl{
+  direction: rtl;
+}
+
 .SingleDatePicker__picker--direction-left {
   left: 0;
 }

--- a/css/SingleDatePicker.scss
+++ b/css/SingleDatePicker.scss
@@ -6,7 +6,7 @@
 }
 
 .SingleDatePicker__picker {
-  z-index: 1;
+  z-index: $react-dates-z-index + 1;
   background-color: $react-dates-color-white;
   position: absolute;
   top: $react-dates-spacing-vertical-picker;
@@ -47,7 +47,7 @@
   top: 0;
   right: 0;
   padding: 15px;
-  z-index: 2;
+  z-index: $react-dates-z-index + 2;
 
   svg {
     height: 15px;

--- a/css/SingleDatePickerInput.scss
+++ b/css/SingleDatePickerInput.scss
@@ -4,7 +4,9 @@
   background-color: $react-dates-color-white;
   border: 1px solid $react-dates-color-border;
 }
-
+.SingleDatePickerInput--rtl{
+  direction: rtl;
+}
 .SingleDatePickerInput__clear-date {
   background: none;
   border: 0;

--- a/css/SingleDatePickerInput.scss
+++ b/css/SingleDatePickerInput.scss
@@ -4,9 +4,11 @@
   background-color: $react-dates-color-white;
   border: 1px solid $react-dates-color-border;
 }
-.SingleDatePickerInput--rtl{
+
+.SingleDatePickerInput--rtl {
   direction: rtl;
 }
+
 .SingleDatePickerInput__clear-date {
   background: none;
   border: 0;

--- a/css/variables.scss
+++ b/css/variables.scss
@@ -4,8 +4,6 @@ $react-dates-width-tooltip-arrow: 20px !default;
 $react-dates-spacing-vertical-picker: 72px !default;
 
 $react-dates-color-primary: #00a699 !default;
-$react-dates-color-primary-dark: #00514a !default;
-$react-date-color-primary-dark-1: #008489 !default;
 $react-dates-color-primary-shade-1: #33dacd !default;
 $react-dates-color-primary-shade-2: #66e2da !default;
 $react-dates-color-primary-shade-3: #80e8e0 !default;

--- a/css/variables.scss
+++ b/css/variables.scss
@@ -26,3 +26,5 @@ $react-dates-color-placeholder-text: #757575 !default;
 $react-dates-color-text: #484848 !default;
 $react-dates-color-text-focus: #007a87 !default;
 $react-dates-color-focus: #99ede6 !default;
+
+$react-dates-z-index: 0 !default;

--- a/examples/DateRangePickerWrapper.jsx
+++ b/examples/DateRangePickerWrapper.jsx
@@ -49,6 +49,7 @@ const defaultProps = {
   customCloseIcon: null,
 
   // calendar presentation and interaction related props
+  renderMonth: null,
   orientation: HORIZONTAL_ORIENTATION,
   anchorDirection: ANCHOR_LEFT,
   horizontalMargin: 0,

--- a/examples/DateRangePickerWrapper.jsx
+++ b/examples/DateRangePickerWrapper.jsx
@@ -58,6 +58,7 @@ const defaultProps = {
   numberOfMonths: 2,
   keepOpenOnDateSelect: false,
   reopenPickerOnClearDates: false,
+  isRTL: false,
 
   // navigation related props
   navPrev: null,

--- a/examples/DayPickerRangeControllerWrapper.jsx
+++ b/examples/DayPickerRangeControllerWrapper.jsx
@@ -44,6 +44,8 @@ const propTypes = forbidExtraProps({
 
   // i18n
   monthFormat: PropTypes.string,
+
+  isRTL: PropTypes.bool,
 });
 
 const defaultProps = {
@@ -68,6 +70,7 @@ const defaultProps = {
   onOutsideClick() {},
   keepOpenOnDateSelect: false,
   renderCalendarInfo: null,
+  isRTL: false,
 
   // navigation related props
   navPrev: null,

--- a/examples/SingleDatePickerWrapper.jsx
+++ b/examples/SingleDatePickerWrapper.jsx
@@ -38,6 +38,7 @@ const defaultProps = {
   showClearDate: false,
 
   // calendar presentation and interaction related props
+  renderMonth: null,
   orientation: HORIZONTAL_ORIENTATION,
   anchorDirection: ANCHOR_LEFT,
   horizontalMargin: 0,
@@ -53,9 +54,6 @@ const defaultProps = {
   navNext: null,
   onPrevMonthClick() {},
   onNextMonthClick() {},
-
-  // month presentation and interaction related props
-  renderMonth: null,
 
   // day presentation and interaction related props
   renderDay: null,

--- a/examples/SingleDatePickerWrapper.jsx
+++ b/examples/SingleDatePickerWrapper.jsx
@@ -15,6 +15,7 @@ const propTypes = {
   // example props for the demo
   autoFocus: PropTypes.bool,
   initialDate: momentPropTypes.momentObj,
+  isRTL: PropTypes.bool,
 
   ...omit(SingleDatePickerShape, [
     'date',

--- a/examples/SingleDatePickerWrapper.jsx
+++ b/examples/SingleDatePickerWrapper.jsx
@@ -15,7 +15,6 @@ const propTypes = {
   // example props for the demo
   autoFocus: PropTypes.bool,
   initialDate: momentPropTypes.momentObj,
-  isRTL: PropTypes.bool,
 
   ...omit(SingleDatePickerShape, [
     'date',
@@ -48,6 +47,7 @@ const defaultProps = {
   numberOfMonths: 2,
   keepOpenOnDateSelect: false,
   reopenPickerOnClearDate: false,
+  isRTL: false,
 
   // navigation related props
   navPrev: null,

--- a/examples/SingleDatePickerWrapper.jsx
+++ b/examples/SingleDatePickerWrapper.jsx
@@ -54,6 +54,9 @@ const defaultProps = {
   onPrevMonthClick() {},
   onNextMonthClick() {},
 
+  // month presentation and interaction related props
+  renderMonth: null,
+
   // day presentation and interaction related props
   renderDay: null,
   enableOutsideDays: false,

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "babel-loader": "^6.4.1",
     "babel-plugin-istanbul": "^4.1.1",
     "babel-plugin-syntax-jsx": "^6.18.0",
+    "babel-plugin-transform-replace-object-assign": "^0.2.1",
     "babel-preset-airbnb": "^2.2.0",
     "babel-register": "^6.22.0",
     "chai": "^3.5.0",
@@ -105,6 +106,7 @@
     "classnames": "^2.2.5",
     "consolidated-events": "^1.0.1",
     "lodash.throttle": "^4.1.1",
+    "object.assign": "^4.0.4",
     "prop-types": "^15.5.6",
     "react-moment-proptypes": "^1.3.0",
     "react-portal": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "mocha": "^3.2.0",
     "mocha-wrap": "^2.1.0",
     "moment": "^2.17.1 && < 2.18.0",
+    "moment-jalaali": "^0.6.1",
     "node-sass": "^4.4.0",
     "nyc": "^10.1.2",
     "raw-loader": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dates",
-  "version": "10.1.2",
+  "version": "10.2.0",
   "description": "A responsive and accessible date range picker component built with React",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dates",
-  "version": "10.1.1",
+  "version": "10.1.2",
   "description": "A responsive and accessible date range picker component built with React",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
   },
   "dependencies": {
     "airbnb-prop-types": "^2.4.1",
-    "array-includes": "^3.0.2",
     "classnames": "^2.2.5",
     "consolidated-events": "^1.0.1",
     "lodash.throttle": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dates",
-  "version": "10.2.0",
+  "version": "11.0.0",
   "description": "A responsive and accessible date range picker component built with React",
   "main": "index.js",
   "scripts": {

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -16,7 +16,7 @@ const propTypes = forbidExtraProps({
   day: momentPropTypes.momentObj,
   daySize: nonNegativeInteger,
   isOutsideDay: PropTypes.bool,
-  modifiers: PropTypes.object,
+  modifiers: PropTypes.instanceOf(Set),
   isFocused: PropTypes.bool,
   tabIndex: PropTypes.oneOf([0, -1]),
   onDayClick: PropTypes.func,
@@ -32,7 +32,7 @@ const defaultProps = {
   day: moment(),
   daySize: DAY_SIZE,
   isOutsideDay: false,
-  modifiers: {},
+  modifiers: new Set(),
   isFocused: false,
   tabIndex: -1,
   onDayClick() {},
@@ -43,10 +43,6 @@ const defaultProps = {
   // internationalization
   phrases: CalendarDayPhrases,
 };
-
-export function getModifiersForDay(modifiers, day) {
-  return day ? Object.keys(modifiers).filter(key => modifiers[key](day)) : [];
-}
 
 export default class CalendarDay extends React.Component {
   shouldComponentUpdate(nextProps, nextState) {
@@ -93,12 +89,9 @@ export default class CalendarDay extends React.Component {
 
     if (!day) return <td />;
 
-    const modifiersForDay = getModifiersForDay(modifiers, day);
-
     const className = cx('CalendarDay', {
       'CalendarDay--outside': isOutsideDay,
-    }, modifiersForDay.map(mod => `CalendarDay--${mod}`));
-
+    }, Array.from(modifiers, mod => `CalendarDay--${mod}`));
 
     const formattedDate = `${day.format('dddd')}, ${day.format('LL')}`;
 

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -43,7 +43,6 @@ const propTypes = forbidExtraProps({
   // i18n
   monthFormat: PropTypes.string,
   phrases: PropTypes.shape(getPhrasePropTypes(CalendarDayPhrases)),
-
 });
 
 const defaultProps = {
@@ -64,7 +63,6 @@ const defaultProps = {
   // i18n
   monthFormat: 'MMMM YYYY', // english locale
   phrases: CalendarDayPhrases,
-
 };
 
 export default class CalendarMonth extends React.Component {

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -15,6 +15,7 @@ import CalendarDay from './CalendarDay';
 
 import getCalendarMonthWeeks from '../utils/getCalendarMonthWeeks';
 import isSameDay from '../utils/isSameDay';
+import toISODateString from '../utils/toISODateString';
 
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 
@@ -132,13 +133,13 @@ export default class CalendarMonth extends React.Component {
                     isOutsideDay={!day || day.month() !== month.month()}
                     tabIndex={isVisible && isSameDay(day, focusedDate) ? 0 : -1}
                     isFocused={isFocused}
-                    modifiers={modifiers}
                     key={dayOfWeek}
                     onDayMouseEnter={onDayMouseEnter}
                     onDayMouseLeave={onDayMouseLeave}
                     onDayClick={onDayClick}
                     renderDay={renderDay}
                     phrases={phrases}
+                    modifiers={modifiers[toISODateString(day)]}
                   />
                 ))}
               </tr>

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -35,6 +35,7 @@ const propTypes = forbidExtraProps({
   onDayClick: PropTypes.func,
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
+  renderMonth: PropTypes.func,
   renderDay: PropTypes.func,
 
   focusedDate: momentPropTypes.momentObj, // indicates focusable day
@@ -55,6 +56,7 @@ const defaultProps = {
   onDayClick() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
+  renderMonth: null,
   renderDay: null,
 
   focusedDate: null,
@@ -96,6 +98,7 @@ export default class CalendarMonth extends React.Component {
       onDayClick,
       onDayMouseEnter,
       onDayMouseLeave,
+      renderMonth,
       renderDay,
       daySize,
       focusedDate,
@@ -104,7 +107,7 @@ export default class CalendarMonth extends React.Component {
     } = this.props;
 
     const { weeks } = this.state;
-    const monthTitle = month.format(monthFormat);
+    const monthTitle = renderMonth ? renderMonth(month) : month.format(monthFormat);
 
     const calendarMonthClasses = cx('CalendarMonth', {
       'CalendarMonth--horizontal': orientation === HORIZONTAL_ORIENTATION,

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -43,6 +43,7 @@ const propTypes = forbidExtraProps({
   // i18n
   monthFormat: PropTypes.string,
   phrases: PropTypes.shape(getPhrasePropTypes(CalendarDayPhrases)),
+
 });
 
 const defaultProps = {
@@ -63,6 +64,7 @@ const defaultProps = {
   // i18n
   monthFormat: 'MMMM YYYY', // english locale
   phrases: CalendarDayPhrases,
+
 };
 
 export default class CalendarMonth extends React.Component {

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -37,6 +37,7 @@ const propTypes = forbidExtraProps({
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
   onMonthTransitionEnd: PropTypes.func,
+  renderMonth: PropTypes.func,
   renderDay: PropTypes.func,
   transformValue: PropTypes.string,
   daySize: nonNegativeInteger,
@@ -60,6 +61,7 @@ const defaultProps = {
   onDayMouseEnter() {},
   onDayMouseLeave() {},
   onMonthTransitionEnd() {},
+  renderMonth: null,
   renderDay: null,
   transformValue: 'none',
   daySize: DAY_SIZE,
@@ -165,6 +167,7 @@ export default class CalendarMonthGrid extends React.Component {
       onDayMouseEnter,
       onDayMouseLeave,
       onDayClick,
+      renderMonth,
       renderDay,
       onMonthTransitionEnd,
       focusedDate,
@@ -217,6 +220,7 @@ export default class CalendarMonthGrid extends React.Component {
               onDayMouseEnter={onDayMouseEnter}
               onDayMouseLeave={onDayMouseLeave}
               onDayClick={onDayClick}
+              renderMonth={renderMonth}
               renderDay={renderDay}
               daySize={daySize}
               focusedDate={isVisible ? focusedDate : null}

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -15,6 +15,8 @@ import CalendarMonth from './CalendarMonth';
 import isTransitionEndSupported from '../utils/isTransitionEndSupported';
 import getTransformStyles from '../utils/getTransformStyles';
 import getCalendarMonthWidth from '../utils/getCalendarMonthWidth';
+import toISOMonthString from '../utils/toISOMonthString';
+import isAfterDay from '../utils/isAfterDay';
 
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 
@@ -113,7 +115,7 @@ export default class CalendarMonthGrid extends React.Component {
     let newMonths = months;
 
     if (hasMonthChanged && !hasNumberOfMonthsChanged) {
-      if (initialMonth.isAfter(this.props.initialMonth)) {
+      if (isAfterDay(initialMonth, this.props.initialMonth)) {
         newMonths = months.slice(1);
         newMonths.push(months[months.length - 1].clone().add(1, 'month'));
       } else {
@@ -208,13 +210,14 @@ export default class CalendarMonthGrid extends React.Component {
         {months.map((month, i) => {
           const isVisible =
             (i >= firstVisibleMonthIndex) && (i < firstVisibleMonthIndex + numberOfMonths);
+          const monthString = toISOMonthString(month);
           return (
             <CalendarMonth
-              key={month.format('YYYY-MM')}
+              key={monthString}
               month={month}
               isVisible={isVisible}
               enableOutsideDays={enableOutsideDays}
-              modifiers={modifiers}
+              modifiers={modifiers[monthString]}
               monthFormat={monthFormat}
               orientation={orientation}
               onDayMouseEnter={onDayMouseEnter}

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -46,7 +46,6 @@ const propTypes = forbidExtraProps({
   // i18n
   monthFormat: PropTypes.string,
   phrases: PropTypes.shape(getPhrasePropTypes(CalendarDayPhrases)),
-
 });
 
 const defaultProps = {
@@ -70,7 +69,6 @@ const defaultProps = {
   // i18n
   monthFormat: 'MMMM YYYY', // english locale
   phrases: CalendarDayPhrases,
-
 };
 
 function getMonths(initialMonth, numberOfMonths) {

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -46,6 +46,7 @@ const propTypes = forbidExtraProps({
   // i18n
   monthFormat: PropTypes.string,
   phrases: PropTypes.shape(getPhrasePropTypes(CalendarDayPhrases)),
+
 });
 
 const defaultProps = {
@@ -69,6 +70,7 @@ const defaultProps = {
   // i18n
   monthFormat: 'MMMM YYYY', // english locale
   phrases: CalendarDayPhrases,
+
 };
 
 function getMonths(initialMonth, numberOfMonths) {

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -65,6 +65,7 @@ const defaultProps = {
   keepOpenOnDateSelect: false,
   reopenPickerOnClearDates: false,
   renderCalendarInfo: null,
+  hideKeyboardShortcutsPanel: false,
   daySize: DAY_SIZE,
 
   // navigation related props
@@ -298,6 +299,7 @@ export default class DateRangePicker extends React.Component {
       renderDay,
       renderCalendarInfo,
       initialVisibleMonth,
+      hideKeyboardShortcutsPanel,
       customCloseIcon,
       onClose,
       phrases,
@@ -336,6 +338,7 @@ export default class DateRangePicker extends React.Component {
           withPortal={withPortal || withFullScreenPortal}
           daySize={daySize}
           initialVisibleMonth={initialVisibleMonthThunk}
+          hideKeyboardShortcutsPanel={hideKeyboardShortcutsPanel}
           navPrev={navPrev}
           navNext={navNext}
           minimumNights={minimumNights}

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -67,6 +67,7 @@ const defaultProps = {
   renderCalendarInfo: null,
   hideKeyboardShortcutsPanel: false,
   daySize: DAY_SIZE,
+  isRTL: false,
 
   // navigation related props
   navPrev: null,
@@ -199,7 +200,9 @@ export default class DateRangePicker extends React.Component {
       withPortal,
       withFullScreenPortal,
       anchorDirection,
+      isRTL,
     } = this.props;
+
     const dayPickerClassName = cx('DateRangePicker__picker', {
       'DateRangePicker__picker--direction-left': anchorDirection === ANCHOR_LEFT,
       'DateRangePicker__picker--direction-right': anchorDirection === ANCHOR_RIGHT,
@@ -207,6 +210,7 @@ export default class DateRangePicker extends React.Component {
       'DateRangePicker__picker--vertical': orientation === VERTICAL_ORIENTATION,
       'DateRangePicker__picker--portal': withPortal || withFullScreenPortal,
       'DateRangePicker__picker--full-screen-portal': withFullScreenPortal,
+      'DateRangePicker__picker--rtl': isRTL,
     });
 
     return dayPickerClassName;
@@ -303,6 +307,7 @@ export default class DateRangePicker extends React.Component {
       customCloseIcon,
       onClose,
       phrases,
+      isRTL,
     } = this.props;
     const { dayPickerContainerStyles, isDayPickerFocused, showKeyboardShortcuts } = this.state;
 
@@ -352,6 +357,7 @@ export default class DateRangePicker extends React.Component {
           showKeyboardShortcuts={showKeyboardShortcuts}
           onBlur={this.onDayPickerBlur}
           phrases={phrases}
+          isRTL={isRTL}
         />
 
         {withFullScreenPortal && (
@@ -396,6 +402,7 @@ export default class DateRangePicker extends React.Component {
       keepOpenOnDateSelect,
       onDatesChange,
       onClose,
+      isRTL,
     } = this.props;
 
     const { isDateRangePickerInputFocused } = this.state;
@@ -435,6 +442,7 @@ export default class DateRangePicker extends React.Component {
             phrases={phrases}
             screenReaderMessage={screenReaderInputMessage}
             isFocused={isDateRangePickerInputFocused}
+            isRTL={isRTL}
           />
 
           {this.maybeRenderDayPickerWithPortal()}

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -55,6 +55,7 @@ const defaultProps = {
   customCloseIcon: null,
 
   // calendar presentation and interaction related props
+  renderMonth: null,
   orientation: HORIZONTAL_ORIENTATION,
   anchorDirection: ANCHOR_LEFT,
   horizontalMargin: 0,
@@ -281,6 +282,7 @@ export default class DateRangePicker extends React.Component {
       numberOfMonths,
       orientation,
       monthFormat,
+      renderMonth,
       navPrev,
       navNext,
       onPrevMonthClick,
@@ -335,6 +337,7 @@ export default class DateRangePicker extends React.Component {
           startDate={startDate}
           endDate={endDate}
           monthFormat={monthFormat}
+          renderMonth={renderMonth}
           withPortal={withPortal || withFullScreenPortal}
           daySize={daySize}
           initialVisibleMonth={initialVisibleMonthThunk}

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -8,6 +8,7 @@ import getPhrasePropTypes from '../utils/getPhrasePropTypes';
 
 import DateInput from './DateInput';
 import RightArrow from '../svg/arrow-right.svg';
+import LeftArrow from '../svg/arrow-left.svg';
 import CloseButton from '../svg/close.svg';
 import CalendarIcon from '../svg/calendar.svg';
 
@@ -52,6 +53,8 @@ const propTypes = forbidExtraProps({
 
   // i18n
   phrases: PropTypes.shape(getPhrasePropTypes(DateRangePickerInputPhrases)),
+
+  isRTL: PropTypes.bool,
 });
 
 const defaultProps = {
@@ -91,6 +94,8 @@ const defaultProps = {
 
   // i18n
   phrases: DateRangePickerInputPhrases,
+
+  isRTL: false,
 };
 
 export default class DateRangePickerInput extends React.Component {
@@ -149,18 +154,19 @@ export default class DateRangePickerInput extends React.Component {
       customCloseIcon,
       isFocused,
       phrases,
+      isRTL,
     } = this.props;
 
     const inputIcon = customInputIcon || (<CalendarIcon />);
-    const arrowIcon = customArrowIcon || (<RightArrow />);
+    const arrowIcon = customArrowIcon || (isRTL ? <LeftArrow /> : <RightArrow />);
     const closeIcon = customCloseIcon || (<CloseButton />);
-
     const screenReaderText = screenReaderMessage || phrases.keyboardNavigationInstructions;
 
     return (
       <div
         className={cx('DateRangePickerInput', {
           'DateRangePickerInput--disabled': disabled,
+          'DateRangePickerInput--rtl': isRTL,
         })}
       >
         {(showDefaultInputIcon || customInputIcon !== null) && (

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -58,6 +58,8 @@ const propTypes = forbidExtraProps({
 
   // i18n
   phrases: PropTypes.shape(getPhrasePropTypes(DateRangePickerInputPhrases)),
+
+  isRTL: PropTypes.bool,
 });
 
 const defaultProps = {
@@ -99,6 +101,8 @@ const defaultProps = {
 
   // i18n
   phrases: DateRangePickerInputPhrases,
+
+  isRTL: false,
 };
 
 export default class DateRangePickerInputController extends React.Component {
@@ -227,6 +231,7 @@ export default class DateRangePickerInputController extends React.Component {
       phrases,
       onArrowDown,
       onQuestionMark,
+      isRTL,
     } = this.props;
 
     const startDateString = this.getDateString(startDate);
@@ -266,6 +271,7 @@ export default class DateRangePickerInputController extends React.Component {
         screenReaderMessage={screenReaderMessage}
         onArrowDown={onArrowDown}
         onQuestionMark={onQuestionMark}
+        isRTL={isRTL}
       />
     );
   }

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -173,19 +173,20 @@ export default class DayPicker extends React.Component {
     super(props);
 
     const currentMonth = props.hidden ? moment() : props.initialVisibleMonth();
-    const translationValueRTL = -getCalendarMonthWidth(props.daySize);
 
     let focusedDate = currentMonth.clone().startOf('month');
     if (props.getFirstFocusableDay) {
       focusedDate = props.getFirstFocusableDay(currentMonth);
     }
 
+    const translationValue =
+      props.isRTL && this.isHorizontal() ? -getCalendarMonthWidth(props.daySize) : 0;
+
     this.hasSetInitialVisibleMonth = !props.hidden;
     this.state = {
-      translationValueRTL,
       currentMonth,
       monthTransition: null,
-      translationValue: props.isRTL && this.isHorizontal() ? translationValueRTL : 0,
+      translationValue,
       scrollableMonthMultiple: 1,
       calendarMonthWidth: getCalendarMonthWidth(props.daySize),
       focusedDate: (!props.hidden || props.isFocused) ? focusedDate : null,
@@ -371,7 +372,6 @@ export default class DayPicker extends React.Component {
   }
 
   onPrevMonthClick(nextFocusedDate, e) {
-    const { translationValueRTL } = this.state;
     const { isRTL } = this.props;
 
     if (e) e.preventDefault();
@@ -384,7 +384,7 @@ export default class DayPicker extends React.Component {
       this.isVertical() ? this.getMonthHeightByIndex(0) : this.dayPickerWidth;
 
     if (isRTL && this.isHorizontal()) {
-      translationValue = translationValueRTL - this.dayPickerWidth;
+      translationValue = -2 * this.dayPickerWidth;
     }
 
     // The first CalendarMonth is always positioned absolute at top: 0 or left: 0
@@ -404,7 +404,6 @@ export default class DayPicker extends React.Component {
   }
 
   onNextMonthClick(nextFocusedDate, e) {
-    const { translationValueRTL } = this.state;
     const { isRTL } = this.props;
 
     if (e) e.preventDefault();
@@ -417,7 +416,7 @@ export default class DayPicker extends React.Component {
       this.isVertical() ? -this.getMonthHeightByIndex(1) : -this.dayPickerWidth;
 
     if (isRTL && this.isHorizontal()) {
-      translationValue = this.dayPickerWidth + translationValueRTL;
+      translationValue = 0;
     }
 
     this.setState({
@@ -517,8 +516,6 @@ export default class DayPicker extends React.Component {
       focusedDate,
       nextFocusedDate,
       withMouseInteractions,
-      translationValueRTL,
-      withMouseInteractions,
     } = this.state;
 
     if (!monthTransition) return;
@@ -547,7 +544,7 @@ export default class DayPicker extends React.Component {
     this.setState({
       currentMonth: newMonth,
       monthTransition: null,
-      translationValue: (this.props.isRTL && this.isHorizontal()) ? translationValueRTL : 0,
+      translationValue: (this.props.isRTL && this.isHorizontal()) ? -this.dayPickerWidth : 0,
       nextFocusedDate: null,
       focusedDate: newFocusedDate,
     }, () => {
@@ -582,10 +579,11 @@ export default class DayPicker extends React.Component {
   }
 
   translateFirstDayPickerForAnimation(translationValue) {
-    const shouldRTL = this.props.isRTL && this.isHorizontal();
+    const { isRTL } = this.props;
+
     let convertedTranslationValue = -translationValue;
-    if (shouldRTL) {
-      const positiveTranslationValue = Math.abs(translationValue - this.state.translationValueRTL);
+    if (isRTL && this.isHorizontal()) {
+      const positiveTranslationValue = Math.abs(translationValue + this.dayPickerWidth);
       convertedTranslationValue = positiveTranslationValue;
     }
     const transformType = this.isVertical() ? 'translateY' : 'translateX';
@@ -648,7 +646,7 @@ export default class DayPicker extends React.Component {
   }
 
   renderWeekHeader(index) {
-    const { daySize, orientation, isRTL } = this.props;
+    const { daySize, orientation } = this.props;
     const { calendarMonthWidth } = this.state;
     const verticalScrollable = orientation === VERTICAL_SCROLLABLE;
     const horizontalStyle = {
@@ -676,7 +674,7 @@ export default class DayPicker extends React.Component {
 
     return (
       <div
-        className={cx('DayPicker__week-header', { 'DayPicker__week-header--rtl': isRTL })}
+        className="DayPicker__week-header"
         key={`week-${index}`}
         style={style}
       >

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -48,6 +48,7 @@ const propTypes = forbidExtraProps({
   hidden: PropTypes.bool,
   initialVisibleMonth: PropTypes.func,
   renderCalendarInfo: PropTypes.func,
+  hideKeyboardShortcutsPanel: PropTypes.bool,
   daySize: nonNegativeInteger,
 
   // navigation props
@@ -84,6 +85,7 @@ export const defaultProps = {
   hidden: false,
   initialVisibleMonth: () => moment(),
   renderCalendarInfo: null,
+  hideKeyboardShortcutsPanel: false,
   daySize: DAY_SIZE,
 
   // navigation props
@@ -385,6 +387,7 @@ export default class DayPicker extends React.Component {
     this.setState({
       monthTransition: PREV_TRANSITION,
       translationValue,
+      focusedDate: null,
       nextFocusedDate,
     });
   }
@@ -401,6 +404,7 @@ export default class DayPicker extends React.Component {
     this.setState({
       monthTransition: NEXT_TRANSITION,
       translationValue,
+      focusedDate: null,
       nextFocusedDate,
     });
   }
@@ -488,7 +492,13 @@ export default class DayPicker extends React.Component {
   }
 
   updateStateAfterMonthTransition() {
-    const { currentMonth, monthTransition, focusedDate, nextFocusedDate } = this.state;
+    const {
+      currentMonth,
+      monthTransition,
+      focusedDate,
+      nextFocusedDate,
+      withMouseInteractions,
+    } = this.state;
 
     if (!monthTransition) return;
 
@@ -502,7 +512,7 @@ export default class DayPicker extends React.Component {
     let newFocusedDate = null;
     if (nextFocusedDate) {
       newFocusedDate = nextFocusedDate;
-    } else if (focusedDate) {
+    } else if (!focusedDate && !withMouseInteractions) {
       newFocusedDate = this.getFocusedDay(newMonth);
     }
 
@@ -522,7 +532,7 @@ export default class DayPicker extends React.Component {
     }, () => {
       // we don't want to focus on the relevant calendar day after a month transition
       // if the user is navigating around using a mouse
-      if (this.state.withMouseInteractions) {
+      if (withMouseInteractions) {
         const activeElement = getActiveElement();
         if (activeElement && activeElement !== document.body) {
           activeElement.blur();
@@ -674,6 +684,7 @@ export default class DayPicker extends React.Component {
       onDayMouseLeave,
       renderDay,
       renderCalendarInfo,
+      hideKeyboardShortcutsPanel,
       onOutsideClick,
       monthFormat,
       daySize,
@@ -792,7 +803,7 @@ export default class DayPicker extends React.Component {
               {verticalScrollable && this.renderNavigation()}
             </div>
 
-            {!isTouch &&
+            {!isTouch && !hideKeyboardShortcutsPanel &&
               <DayPickerKeyboardShortcuts
                 block={this.isVertical() && !withPortal}
                 buttonLocation={keyboardShortcutButtonLocation}

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -57,6 +57,9 @@ const propTypes = forbidExtraProps({
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
 
+  // month props
+  renderMonth: PropTypes.func,
+
   // day props
   modifiers: PropTypes.object,
   renderDay: PropTypes.func,
@@ -93,6 +96,9 @@ export const defaultProps = {
   navNext: null,
   onPrevMonthClick() {},
   onNextMonthClick() {},
+
+  // month props
+  renderMonth: null,
 
   // day props
   modifiers: {},
@@ -682,6 +688,7 @@ export default class DayPicker extends React.Component {
       onDayClick,
       onDayMouseEnter,
       onDayMouseLeave,
+      renderMonth,
       renderDay,
       renderCalendarInfo,
       hideKeyboardShortcutsPanel,
@@ -792,6 +799,7 @@ export default class DayPicker extends React.Component {
                 onDayClick={onDayClick}
                 onDayMouseEnter={onDayMouseEnter}
                 onDayMouseLeave={onDayMouseLeave}
+                renderMonth={renderMonth}
                 renderDay={renderDay}
                 onMonthTransitionEnd={this.updateStateAfterMonthTransition}
                 monthFormat={monthFormat}

--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -27,6 +27,8 @@ const propTypes = forbidExtraProps({
 
   // internationalization
   phrases: PropTypes.shape(getPhrasePropTypes(DayPickerNavigationPhrases)),
+
+  isRTL: PropTypes.bool,
 });
 
 const defaultProps = {
@@ -39,6 +41,7 @@ const defaultProps = {
 
   // internationalization
   phrases: DayPickerNavigationPhrases,
+  isRTL: false,
 };
 
 export default function DayPickerNavigation(props) {
@@ -49,6 +52,7 @@ export default function DayPickerNavigation(props) {
     onNextMonthClick,
     orientation,
     phrases,
+    isRTL,
   } = props;
 
   const isVertical = orientation !== HORIZONTAL_ORIENTATION;
@@ -61,10 +65,16 @@ export default function DayPickerNavigation(props) {
   if (!navPrevIcon) {
     isDefaultNavPrev = true;
     navPrevIcon = isVertical ? <ChevronUp /> : <LeftArrow />;
+    if (isRTL && !isVertical) {
+      navPrevIcon = <RightArrow />;
+    }
   }
   if (!navNextIcon) {
     isDefaultNavNext = true;
     navNextIcon = isVertical ? <ChevronDown /> : <RightArrow />;
+    if (isRTL && !isVertical) {
+      navNextIcon = <LeftArrow />;
+    }
   }
 
   const navClassNames = cx('DayPickerNavigation', {
@@ -74,14 +84,15 @@ export default function DayPickerNavigation(props) {
   });
   const prevClassNames = cx('DayPickerNavigation__prev', {
     'DayPickerNavigation__prev--default': isDefaultNavPrev,
+    'DayPickerNavigation__prev--rtl': isRTL,
   });
   const nextClassNames = cx('DayPickerNavigation__next', {
     'DayPickerNavigation__next--default': isDefaultNavNext,
+    'DayPickerNavigation__next--rtl': isRTL,
   });
 
   return (
     <div className={navClassNames}>
-
       {!isVerticalScrollable && (
         <button
           type="button"

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -66,6 +66,8 @@ const propTypes = forbidExtraProps({
   // i18n
   monthFormat: PropTypes.string,
   phrases: PropTypes.shape(getPhrasePropTypes(DayPickerPhrases)),
+
+  isRTL: PropTypes.bool,
 });
 
 const defaultProps = {
@@ -110,6 +112,8 @@ const defaultProps = {
   // i18n
   monthFormat: 'MMMM YYYY',
   phrases: DayPickerPhrases,
+
+  isRTL: false,
 };
 
 export default class DayPickerRangeController extends React.Component {
@@ -326,6 +330,7 @@ export default class DayPickerRangeController extends React.Component {
       onBlur,
       isFocused,
       showKeyboardShortcuts,
+      isRTL,
     } = this.props;
 
     const { phrases } = this.state;
@@ -389,6 +394,7 @@ export default class DayPickerRangeController extends React.Component {
         onBlur={onBlur}
         showKeyboardShortcuts={showKeyboardShortcuts}
         phrases={phrases}
+        isRTL={isRTL}
       />
     );
   }

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -41,6 +41,7 @@ const propTypes = forbidExtraProps({
   isDayHighlighted: PropTypes.func,
 
   // DayPicker props
+  renderMonth: PropTypes.func,
   enableOutsideDays: PropTypes.bool,
   numberOfMonths: PropTypes.number,
   orientation: ScrollableOrientationShape,
@@ -84,6 +85,7 @@ const defaultProps = {
   isDayHighlighted() {},
 
   // DayPicker props
+  renderMonth: null,
   enableOutsideDays: false,
   numberOfMonths: 1,
   orientation: HORIZONTAL_ORIENTATION,
@@ -308,6 +310,7 @@ export default class DayPickerRangeController extends React.Component {
       numberOfMonths,
       orientation,
       monthFormat,
+      renderMonth,
       navPrev,
       navNext,
       onOutsideClick,
@@ -374,6 +377,7 @@ export default class DayPickerRangeController extends React.Component {
         onPrevMonthClick={onPrevMonthClick}
         onNextMonthClick={onNextMonthClick}
         monthFormat={monthFormat}
+        renderMonth={renderMonth}
         withPortal={withPortal}
         hidden={!focusedInput}
         initialVisibleMonth={initialVisibleMonth}

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -46,6 +46,7 @@ const propTypes = forbidExtraProps({
   orientation: ScrollableOrientationShape,
   withPortal: PropTypes.bool,
   initialVisibleMonth: PropTypes.func,
+  hideKeyboardShortcutsPanel: PropTypes.bool,
   daySize: nonNegativeInteger,
 
   navPrev: PropTypes.node,
@@ -87,7 +88,7 @@ const defaultProps = {
   numberOfMonths: 1,
   orientation: HORIZONTAL_ORIENTATION,
   withPortal: false,
-
+  hideKeyboardShortcutsPanel: false,
   initialVisibleMonth: DayPickerDefaultProps.initialVisibleMonth,
   daySize: DAY_SIZE,
 
@@ -315,6 +316,7 @@ export default class DayPickerRangeController extends React.Component {
       withPortal,
       enableOutsideDays,
       initialVisibleMonth,
+      hideKeyboardShortcutsPanel,
       daySize,
       focusedInput,
       renderDay,
@@ -381,6 +383,7 @@ export default class DayPickerRangeController extends React.Component {
         navNext={navNext}
         renderDay={renderDay}
         renderCalendarInfo={renderCalendarInfo}
+        hideKeyboardShortcutsPanel={hideKeyboardShortcutsPanel}
         isFocused={isFocused}
         getFirstFocusableDay={this.getFirstFocusableDay}
         onBlur={onBlur}

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -12,6 +12,14 @@ import isTouchDevice from '../utils/isTouchDevice';
 import isInclusivelyAfterDay from '../utils/isInclusivelyAfterDay';
 import isNextDay from '../utils/isNextDay';
 import isSameDay from '../utils/isSameDay';
+import isAfterDay from '../utils/isAfterDay';
+import isBeforeDay from '../utils/isBeforeDay';
+
+import getVisibleDays from '../utils/getVisibleDays';
+import isDayVisible from '../utils/isDayVisible';
+
+import toISODateString from '../utils/toISODateString';
+import toISOMonthString from '../utils/toISOMonthString';
 
 import FocusedInputShape from '../shapes/FocusedInputShape';
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
@@ -121,24 +129,184 @@ const defaultProps = {
 export default class DayPickerRangeController extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      hoverDate: null,
-      phrases: props.phrases,
-    };
 
     this.isTouchDevice = isTouchDevice();
     this.today = moment();
+    this.modifiers = {
+      today: day => this.isToday(day),
+      blocked: day => this.isBlocked(day),
+      'blocked-calendar': day => props.isDayBlocked(day),
+      'blocked-out-of-range': day => props.isOutsideRange(day),
+      'highlighted-calendar': day => props.isDayHighlighted(day),
+      valid: day => !this.isBlocked(day),
+      'selected-start': day => this.isStartDate(day),
+      'selected-end': day => this.isEndDate(day),
+      'blocked-minimum-nights': day => this.doesNotMeetMinimumNights(day),
+      'selected-span': day => this.isInSelectedSpan(day),
+      'last-in-range': day => this.isLastInRange(day),
+      hovered: day => this.isHovered(day),
+      'hovered-span': day => this.isInHoveredSpan(day),
+      'after-hovered-start': day => this.isDayAfterHoveredStartDate(day),
+    };
+
+    const { currentMonth, visibleDays } = this.getStateForNewMonth(props);
+
+    this.state = {
+      hoverDate: null,
+      currentMonth,
+      phrases: props.phrases,
+      visibleDays,
+    };
 
     this.onDayClick = this.onDayClick.bind(this);
     this.onDayMouseEnter = this.onDayMouseEnter.bind(this);
     this.onDayMouseLeave = this.onDayMouseLeave.bind(this);
+    this.onPrevMonthClick = this.onPrevMonthClick.bind(this);
+    this.onNextMonthClick = this.onNextMonthClick.bind(this);
     this.getFirstFocusableDay = this.getFirstFocusableDay.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
-    const { focusedInput, phrases } = nextProps;
+    const {
+      startDate,
+      endDate,
+      focusedInput,
+      minimumNights,
+      isOutsideRange,
+      isDayBlocked,
+      isDayHighlighted,
+      phrases,
+      initialVisibleMonth,
+      numberOfMonths,
+      enableOutsideDays,
+    } = nextProps;
+    let { visibleDays } = this.state;
 
-    if (focusedInput !== this.props.focusedInput || phrases !== this.props.phrases) {
+    if (isOutsideRange !== this.props.isOutsideRange) {
+      this.modifiers['blocked-out-of-range'] = day => isOutsideRange(day);
+    }
+
+    if (isDayBlocked !== this.props.isDayBlocked) {
+      this.modifiers['blocked-calendar'] = day => isDayBlocked(day);
+    }
+
+    if (isDayHighlighted !== this.props.isDayHighlighted) {
+      this.modifiers['highlighted-calendar'] = day => isDayHighlighted(day);
+    }
+
+    if (
+      initialVisibleMonth !== this.props.initialVisibleMonth ||
+      numberOfMonths !== this.props.numberOfMonths ||
+      enableOutsideDays !== this.props.enableOutsideDays
+    ) {
+      const newMonthState = this.getStateForNewMonth(nextProps);
+      const currentMonth = newMonthState.currentMonth;
+      visibleDays = newMonthState.visibleDays;
+      this.setState({
+        currentMonth,
+        visibleDays,
+      });
+    }
+
+    const didStartDateChange = startDate !== this.props.startDate;
+    const didEndDateChange = endDate !== this.props.endDate;
+    const didFocusChange = focusedInput !== this.props.focusedInput;
+
+    let modifiers = {};
+
+    if (didStartDateChange) {
+      modifiers = this.deleteModifier(modifiers, this.props.startDate, 'selected-start');
+      modifiers = this.addModifier(modifiers, startDate, 'selected-start');
+    }
+
+    if (didEndDateChange) {
+      modifiers = this.deleteModifier(modifiers, this.props.endDate, 'selected-end');
+      modifiers = this.addModifier(modifiers, endDate, 'selected-end');
+    }
+
+    if (didStartDateChange || didEndDateChange) {
+      if (this.props.startDate && this.props.endDate) {
+        modifiers = this.deleteModifierFromRange(
+          modifiers,
+          this.props.startDate.clone().add(1, 'day'),
+          this.props.endDate,
+          'selected-span',
+        );
+      }
+
+      if (startDate && endDate) {
+        modifiers = this.deleteModifierFromRange(
+          modifiers,
+          startDate,
+          endDate,
+          'hovered-span',
+        );
+
+        modifiers = this.addModifierToRange(
+          modifiers,
+          startDate.clone().add(1, 'day'),
+          endDate,
+          'selected-span',
+        );
+      }
+    }
+
+    if (minimumNights > 0 || minimumNights !== this.props.minimumNights) {
+      if (this.props.startDate && (didFocusChange || didStartDateChange)) {
+        modifiers = this.deleteModifierFromRange(
+          modifiers,
+          this.props.startDate,
+          this.props.startDate.clone().add(minimumNights, 'days'),
+          'blocked-minimum-nights',
+        );
+      }
+
+      if (startDate && focusedInput === END_DATE) {
+        modifiers = this.addModifierToRange(
+          modifiers,
+          startDate,
+          startDate.clone().add(minimumNights, 'days'),
+          'blocked-minimum-nights',
+        );
+      }
+    }
+
+    if (didFocusChange) {
+      Object.values(visibleDays).forEach((days) => {
+        Object.keys(days).forEach((day) => {
+          const momentObj = moment(day);
+          if (isDayBlocked(momentObj)) {
+            modifiers = this.addModifier(modifiers, momentObj, 'blocked-calendar');
+          } else {
+            modifiers = this.deleteModifier(modifiers, momentObj, 'blocked-calendar');
+          }
+
+          if (isDayHighlighted(momentObj)) {
+            modifiers = this.addModifier(modifiers, momentObj, 'highlighted-calendar');
+          } else {
+            modifiers = this.deleteModifier(modifiers, momentObj, 'highlighted-calendar');
+          }
+        });
+      });
+    }
+
+    const today = moment();
+    if (!isSameDay(this.today, today)) {
+      modifiers = this.deleteModifier(modifiers, this.today, 'today');
+      modifiers = this.addModifier(modifiers, today, 'today');
+      this.today = today;
+    }
+
+    if (Object.keys(modifiers).length > 0) {
+      this.setState({
+        visibleDays: {
+          ...visibleDays,
+          ...modifiers,
+        },
+      });
+    }
+
+    if (didFocusChange || phrases !== this.props.phrases) {
       // set the appropriate CalendarDay phrase based on focusedInput
       let chooseAvailableDate = phrases.chooseAvailableDate;
       if (focusedInput === START_DATE) {
@@ -154,10 +322,6 @@ export default class DayPickerRangeController extends React.Component {
         },
       });
     }
-  }
-
-  componentWillUpdate() {
-    this.today = moment();
   }
 
   onDayClick(day, e) {
@@ -200,18 +364,111 @@ export default class DayPickerRangeController extends React.Component {
 
   onDayMouseEnter(day) {
     if (this.isTouchDevice) return;
+    const { startDate, endDate, focusedInput } = this.props;
+    const { hoverDate, visibleDays } = this.state;
+
+    let modifiers = {};
+    modifiers = this.deleteModifier(modifiers, hoverDate, 'hovered');
+    modifiers = this.addModifier(modifiers, day, 'hovered');
+
+    if (startDate && !endDate && focusedInput === END_DATE) {
+      if (isAfterDay(hoverDate, startDate)) {
+        modifiers = this.deleteModifierFromRange(modifiers, startDate, hoverDate, 'hovered-span');
+      }
+
+      if (!this.isBlocked(day) && isAfterDay(day, startDate)) {
+        modifiers = this.addModifierToRange(modifiers, startDate, day, 'hovered-span');
+      }
+    }
+
+    if (!startDate && endDate && focusedInput === START_DATE) {
+      if (isBeforeDay(hoverDate, endDate)) {
+        modifiers = this.deleteModifierFromRange(modifiers, hoverDate, endDate, 'hovered-span');
+      }
+
+      if (!this.isBlocked(day) && isBeforeDay(day, endDate)) {
+        modifiers = this.addModifierToRange(modifiers, day, endDate, 'hovered-span');
+      }
+    }
 
     this.setState({
       hoverDate: day,
+      visibleDays: {
+        ...visibleDays,
+        ...modifiers,
+      },
     });
   }
 
   onDayMouseLeave() {
-    if (this.isTouchDevice) return;
+    const { startDate, endDate } = this.props;
+    const { hoverDate, visibleDays } = this.state;
+    if (this.isTouchDevice || !hoverDate) return;
+
+    let modifiers = {};
+    modifiers = this.deleteModifier(modifiers, hoverDate, 'hovered');
+
+    if (startDate && !endDate && isAfterDay(hoverDate, startDate)) {
+      modifiers = this.deleteModifierFromRange(modifiers, startDate, hoverDate, 'hovered-span');
+    }
+
+    if (!startDate && endDate && isAfterDay(endDate, hoverDate)) {
+      modifiers = this.deleteModifierFromRange(modifiers, hoverDate, endDate, 'hovered-span');
+    }
 
     this.setState({
       hoverDate: null,
+      visibleDays: {
+        ...visibleDays,
+        ...modifiers,
+      },
     });
+  }
+
+  onPrevMonthClick() {
+    const { onPrevMonthClick, numberOfMonths, enableOutsideDays } = this.props;
+    const { currentMonth, visibleDays } = this.state;
+
+    const newVisibleDays = {};
+    Object.keys(visibleDays).sort().slice(0, numberOfMonths + 1).forEach((month) => {
+      newVisibleDays[month] = visibleDays[month];
+    });
+
+    const prevMonth = currentMonth.clone().subtract(1, 'months');
+    const prevMonthVisibleDays = getVisibleDays(prevMonth, 1, enableOutsideDays);
+
+    this.setState({
+      currentMonth: prevMonth,
+      visibleDays: {
+        ...newVisibleDays,
+        ...this.getModifiers(prevMonthVisibleDays),
+      },
+    });
+
+    onPrevMonthClick();
+  }
+
+  onNextMonthClick() {
+    const { onNextMonthClick, numberOfMonths, enableOutsideDays } = this.props;
+    const { currentMonth, visibleDays } = this.state;
+
+    const newVisibleDays = {};
+    Object.keys(visibleDays).sort().slice(1).forEach((month) => {
+      newVisibleDays[month] = visibleDays[month];
+    });
+
+    const nextMonth = currentMonth.clone().add(numberOfMonths, 'month');
+    const nextMonthVisibleDays = getVisibleDays(nextMonth, 1, enableOutsideDays);
+
+    this.setState({
+      currentMonth: currentMonth.clone().add(1, 'month'),
+      visibleDays: {
+        ...newVisibleDays,
+        ...this.getModifiers(nextMonthVisibleDays),
+      },
+    });
+
+    onNextMonthClick();
   }
 
   getFirstFocusableDay(newMonth) {
@@ -230,16 +487,135 @@ export default class DayPickerRangeController extends React.Component {
       const days = [];
       const lastVisibleDay = newMonth.clone().add(numberOfMonths - 1, 'months').endOf('month');
       let currentDay = focusedDate.clone();
-      while (!currentDay.isAfter(lastVisibleDay)) {
+      while (!isAfterDay(currentDay, lastVisibleDay)) {
         currentDay = currentDay.clone().add(1, 'day');
         days.push(currentDay);
       }
 
-      const viableDays = days.filter(day => !this.isBlocked(day) && day.isAfter(focusedDate));
+      const viableDays = days.filter(day => !this.isBlocked(day));
+
       if (viableDays.length > 0) focusedDate = viableDays[0];
     }
 
     return focusedDate;
+  }
+
+  getModifiers(visibleDays) {
+    const modifiers = {};
+    Object.keys(visibleDays).forEach((month) => {
+      modifiers[month] = {};
+      visibleDays[month].forEach((day) => {
+        modifiers[month][toISODateString(day)] = this.getModifiersForDay(day);
+      });
+    });
+
+    return modifiers;
+  }
+
+  getModifiersForDay(day) {
+    return new Set(Object.keys(this.modifiers).filter(modifier => this.modifiers[modifier](day)));
+  }
+
+  getStateForNewMonth(nextProps) {
+    const { initialVisibleMonth, numberOfMonths, enableOutsideDays } = nextProps;
+    const currentMonth = initialVisibleMonth();
+    const visibleDays =
+      this.getModifiers(getVisibleDays(currentMonth, numberOfMonths, enableOutsideDays));
+    return { currentMonth, visibleDays };
+  }
+
+  addModifier(updatedDays, day, modifier) {
+    const { numberOfMonths, enableOutsideDays } = this.props;
+    const { currentMonth, visibleDays } = this.state;
+    if (!day || !isDayVisible(day, currentMonth, numberOfMonths, enableOutsideDays)) {
+      return updatedDays;
+    }
+
+    let monthIso = toISOMonthString(day);
+    let month = updatedDays[monthIso] || visibleDays[monthIso];
+    const iso = toISODateString(day);
+    if (enableOutsideDays) {
+      const startOfMonth = day.clone().startOf('month');
+      const endOfMonth = day.clone().endOf('month');
+      if (
+        isBeforeDay(startOfMonth, currentMonth.clone().startOf('month')) ||
+        isAfterDay(endOfMonth, currentMonth.clone().endOf('month'))
+      ) {
+        monthIso = Object.keys(visibleDays).filter(monthKey => (
+          monthKey !== monthIso && Object.keys(visibleDays[monthKey]).indexOf(iso) > -1
+        ))[0];
+        month = updatedDays[monthIso] || visibleDays[monthIso];
+      }
+    }
+
+    const modifiers = new Set(month[iso]);
+    modifiers.add(modifier);
+    return {
+      ...updatedDays,
+      [monthIso]: {
+        ...month,
+        [iso]: modifiers,
+      },
+    };
+  }
+
+  addModifierToRange(updatedDays, start, end, modifier) {
+    let days = updatedDays;
+
+    let spanStart = start.clone();
+    while (isBeforeDay(spanStart, end)) {
+      days = this.addModifier(days, spanStart, modifier);
+      spanStart = spanStart.clone().add(1, 'day');
+    }
+
+    return days;
+  }
+
+  deleteModifier(updatedDays, day, modifier) {
+    const { numberOfMonths, enableOutsideDays } = this.props;
+    const { currentMonth, visibleDays } = this.state;
+    if (!day || !isDayVisible(day, currentMonth, numberOfMonths, enableOutsideDays)) {
+      return updatedDays;
+    }
+
+    let monthIso = toISOMonthString(day);
+    let month = updatedDays[monthIso] || visibleDays[monthIso];
+    const iso = toISODateString(day);
+    if (enableOutsideDays) {
+      const startOfMonth = day.clone().startOf('month');
+      const endOfMonth = day.clone().endOf('month');
+      if (
+        isBeforeDay(startOfMonth, currentMonth.clone().startOf('month')) ||
+        isAfterDay(endOfMonth, currentMonth.clone().endOf('month'))
+      ) {
+        monthIso = Object.keys(visibleDays).filter(monthKey => (
+          monthKey !== monthIso && Object.keys(visibleDays[monthKey]).indexOf(iso) > -1
+        ))[0];
+        month = updatedDays[monthIso] || visibleDays[monthIso];
+      }
+    }
+
+    const modifiers = new Set(month[iso]);
+    modifiers.delete(modifier);
+    return {
+      ...updatedDays,
+      [monthIso]: {
+        ...month,
+        [iso]: modifiers,
+      },
+    };
+  }
+
+  deleteModifierFromRange(updatedDays, start, end, modifier) {
+    let days = updatedDays;
+
+    let spanStart = start.clone();
+    while (isBeforeDay(spanStart, end)) {
+      days = this.deleteModifier(days, spanStart, modifier);
+      spanStart = spanStart.clone().add(1, 'day');
+    }
+
+    return days;
   }
 
   doesNotMeetMinimumNights(day) {
@@ -255,7 +631,7 @@ export default class DayPickerRangeController extends React.Component {
 
   isDayAfterHoveredStartDate(day) {
     const { startDate, endDate, minimumNights } = this.props;
-    const { hoverDate } = this.state;
+    const { hoverDate } = this.state || {};
     return !!startDate && !endDate && !this.isBlocked(day) && isNextDay(hoverDate, day) &&
       minimumNights > 0 && isSameDay(hoverDate, startDate);
   }
@@ -265,12 +641,13 @@ export default class DayPickerRangeController extends React.Component {
   }
 
   isHovered(day) {
-    return isSameDay(day, this.state.hoverDate);
+    const { hoverDate } = this.state || {};
+    return isSameDay(day, hoverDate);
   }
 
   isInHoveredSpan(day) {
     const { startDate, endDate } = this.props;
-    const { hoverDate } = this.state;
+    const { hoverDate } = this.state || {};
 
     const isForwardRange = !!startDate && !endDate &&
       (day.isBetween(startDate, hoverDate) ||
@@ -308,9 +685,6 @@ export default class DayPickerRangeController extends React.Component {
 
   render() {
     const {
-      isDayBlocked,
-      isDayHighlighted,
-      isOutsideRange,
       numberOfMonths,
       orientation,
       monthFormat,
@@ -318,8 +692,6 @@ export default class DayPickerRangeController extends React.Component {
       navPrev,
       navNext,
       onOutsideClick,
-      onPrevMonthClick,
-      onNextMonthClick,
       withPortal,
       enableOutsideDays,
       initialVisibleMonth,
@@ -328,59 +700,26 @@ export default class DayPickerRangeController extends React.Component {
       focusedInput,
       renderDay,
       renderCalendarInfo,
-      startDate,
-      endDate,
       onBlur,
       isFocused,
       showKeyboardShortcuts,
       isRTL,
     } = this.props;
 
-    const { phrases } = this.state;
-
-    const modifiers = {
-      today: day => this.isToday(day),
-      blocked: day => this.isBlocked(day),
-      'blocked-calendar': day => isDayBlocked(day),
-      'blocked-out-of-range': day => isOutsideRange(day),
-      'highlighted-calendar': day => isDayHighlighted(day),
-      valid: day => !this.isBlocked(day),
-
-      // Modifiers are computed for every CalendarDay, so we omit where
-      // logically possible.
-      ...startDate && {
-        'selected-start': day => this.isStartDate(day),
-      },
-      ...endDate && {
-        'selected-end': day => this.isEndDate(day),
-        'blocked-minimum-nights': day => this.doesNotMeetMinimumNights(day),
-      },
-      ...(startDate && endDate) && {
-        'selected-span': day => this.isInSelectedSpan(day),
-        'last-in-range': day => this.isLastInRange(day),
-      },
-      ...!this.isTouchDevice && {
-        // before anything has been set or after both are set
-        hovered: day => this.isHovered(day),
-
-        // while start date has been set, but end date has not been
-        'hovered-span': day => this.isInHoveredSpan(day),
-        'after-hovered-start': day => this.isDayAfterHoveredStartDate(day),
-      },
-    };
+    const { phrases, visibleDays } = this.state;
 
     return (
       <DayPicker
         ref={(ref) => { this.dayPicker = ref; }}
         orientation={orientation}
         enableOutsideDays={enableOutsideDays}
-        modifiers={modifiers}
+        modifiers={visibleDays}
         numberOfMonths={numberOfMonths}
         onDayClick={this.onDayClick}
         onDayMouseEnter={this.onDayMouseEnter}
         onDayMouseLeave={this.onDayMouseLeave}
-        onPrevMonthClick={onPrevMonthClick}
-        onNextMonthClick={onNextMonthClick}
+        onPrevMonthClick={this.onPrevMonthClick}
+        onNextMonthClick={this.onNextMonthClick}
         monthFormat={monthFormat}
         renderMonth={renderMonth}
         withPortal={withPortal}

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -60,6 +60,7 @@ const defaultProps = {
   renderCalendarInfo: null,
   hideKeyboardShortcutsPanel: false,
   daySize: DAY_SIZE,
+  isRTL: false,
 
   // navigation related props
   navPrev: null,
@@ -251,7 +252,7 @@ export default class SingleDatePicker extends React.Component {
   }
 
   getDayPickerContainerClasses() {
-    const { orientation, withPortal, withFullScreenPortal, anchorDirection } = this.props;
+    const { orientation, withPortal, withFullScreenPortal, anchorDirection, isRTL } = this.props;
     const { hoverDate } = this.state;
 
     const dayPickerClassName = cx('SingleDatePicker__picker', {
@@ -262,6 +263,7 @@ export default class SingleDatePicker extends React.Component {
       'SingleDatePicker__picker--portal': withPortal || withFullScreenPortal,
       'SingleDatePicker__picker--full-screen-portal': withFullScreenPortal,
       'SingleDatePicker__picker--valid-date-hovered': hoverDate && !this.isBlocked(hoverDate),
+      'SingleDatePicker__picker--rtl': isRTL,
     });
 
     return dayPickerClassName;
@@ -397,6 +399,7 @@ export default class SingleDatePicker extends React.Component {
       customCloseIcon,
       phrases,
       daySize,
+      isRTL,
     } = this.props;
     const { dayPickerContainerStyles, isDayPickerFocused } = this.state;
 
@@ -446,6 +449,7 @@ export default class SingleDatePicker extends React.Component {
           onBlur={this.onDayPickerBlur}
           phrases={phrases}
           daySize={daySize}
+          isRTL={isRTL}
         />
 
         {withFullScreenPortal && (
@@ -477,6 +481,7 @@ export default class SingleDatePicker extends React.Component {
       withPortal,
       withFullScreenPortal,
       screenReaderInputMessage,
+      isRTL,
     } = this.props;
 
     const { isInputFocused } = this.state;
@@ -508,6 +513,7 @@ export default class SingleDatePicker extends React.Component {
             onKeyDownArrowDown={this.onDayPickerFocus}
             screenReaderMessage={screenReaderInputMessage}
             phrases={phrases}
+            isRTL={isRTL}
           />
 
           {this.maybeRenderDayPickerWithPortal()}

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -58,6 +58,7 @@ const defaultProps = {
   keepOpenOnDateSelect: false,
   reopenPickerOnClearDate: false,
   renderCalendarInfo: null,
+  hideKeyboardShortcutsPanel: false,
   daySize: DAY_SIZE,
 
   // navigation related props
@@ -392,6 +393,7 @@ export default class SingleDatePicker extends React.Component {
       renderCalendarInfo,
       date,
       initialVisibleMonth,
+      hideKeyboardShortcutsPanel,
       customCloseIcon,
       phrases,
       daySize,
@@ -434,6 +436,7 @@ export default class SingleDatePicker extends React.Component {
           withPortal={withPortal || withFullScreenPortal}
           hidden={!focused}
           initialVisibleMonth={initialVisibleMonthThunk}
+          hideKeyboardShortcutsPanel={hideKeyboardShortcutsPanel}
           navPrev={navPrev}
           navNext={navNext}
           renderDay={renderDay}

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -69,6 +69,9 @@ const defaultProps = {
   onNextMonthClick() {},
   onClose() {},
 
+  // month presentation and interaction related props
+  renderMonth: null,
+
   // day presentation and interaction related props
   renderDay: null,
   enableOutsideDays: false,
@@ -389,6 +392,7 @@ export default class SingleDatePicker extends React.Component {
       withPortal,
       withFullScreenPortal,
       focused,
+      renderMonth,
       renderDay,
       renderCalendarInfo,
       date,
@@ -439,6 +443,7 @@ export default class SingleDatePicker extends React.Component {
           hideKeyboardShortcutsPanel={hideKeyboardShortcutsPanel}
           navPrev={navPrev}
           navNext={navNext}
+          renderMonth={renderMonth}
           renderDay={renderDay}
           renderCalendarInfo={renderCalendarInfo}
           isFocused={isDayPickerFocused}

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -22,7 +22,7 @@ const propTypes = forbidExtraProps({
   showCaret: PropTypes.bool,
   showClearDate: PropTypes.bool,
   customCloseIcon: PropTypes.node,
-
+  isRTL: PropTypes.bool,
   onChange: PropTypes.func,
   onClearDate: PropTypes.func,
   onFocus: PropTypes.func,
@@ -46,6 +46,7 @@ const defaultProps = {
   showCaret: false,
   showClearDate: false,
   customCloseIcon: null,
+  isRTL: false,
 
   onChange() {},
   onClearDate() {},
@@ -103,13 +104,19 @@ export default class SingleDatePickerInput extends React.Component {
       onKeyDownArrowDown,
       screenReaderMessage,
       customCloseIcon,
+      isRTL,
     } = this.props;
 
     const closeIcon = customCloseIcon || (<CloseButton />);
     const screenReaderText = screenReaderMessage || phrases.keyboardNavigationInstructions;
 
     return (
-      <div className="SingleDatePickerInput">
+      <div
+        className={cx('SingleDatePickerInput', {
+          'SingleDatePickerInput--rtl': isRTL,
+        })}
+      >
+
         <DateInput
           id={id}
           placeholder={placeholder} // also used as label

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -68,5 +68,4 @@ export default {
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   monthFormat: PropTypes.string,
   phrases: PropTypes.shape(getPhrasePropTypes(DateRangePickerPhrases)),
-
 };

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -47,6 +47,7 @@ export default {
   keepOpenOnDateSelect: PropTypes.bool,
   reopenPickerOnClearDates: PropTypes.bool,
   renderCalendarInfo: PropTypes.func,
+  hideKeyboardShortcutsPanel: PropTypes.bool,
 
   // navigation related props
   navPrev: PropTypes.node,

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -41,6 +41,7 @@ export default {
   withPortal: PropTypes.bool,
   withFullScreenPortal: PropTypes.bool,
   daySize: nonNegativeInteger,
+  isRTL: PropTypes.bool,
 
   initialVisibleMonth: PropTypes.func,
   numberOfMonths: PropTypes.number,
@@ -67,4 +68,5 @@ export default {
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   monthFormat: PropTypes.string,
   phrases: PropTypes.shape(getPhrasePropTypes(DateRangePickerPhrases)),
+
 };

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -35,6 +35,7 @@ export default {
   customCloseIcon: PropTypes.node,
 
   // calendar presentation and interaction related props
+  renderMonth: PropTypes.func,
   orientation: OrientationShape,
   anchorDirection: anchorDirectionShape,
   horizontalMargin: PropTypes.number,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -38,6 +38,7 @@ export default {
   renderCalendarInfo: PropTypes.func,
   hideKeyboardShortcutsPanel: PropTypes.bool,
   daySize: nonNegativeInteger,
+  isRTL: PropTypes.bool,
 
   // navigation related props
   navPrev: PropTypes.node,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -36,6 +36,7 @@ export default {
   keepOpenOnDateSelect: PropTypes.bool,
   reopenPickerOnClearDate: PropTypes.bool,
   renderCalendarInfo: PropTypes.func,
+  hideKeyboardShortcutsPanel: PropTypes.bool,
   daySize: nonNegativeInteger,
 
   // navigation related props

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -26,6 +26,7 @@ export default {
   customCloseIcon: PropTypes.node,
 
   // calendar presentation and interaction related props
+  renderMonth: PropTypes.func,
   orientation: OrientationShape,
   anchorDirection: anchorDirectionShape,
   horizontalMargin: PropTypes.number,
@@ -46,9 +47,6 @@ export default {
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
   onClose: PropTypes.func,
-
-  // month presentation and interaction related props
-  renderMonth: PropTypes.func,
 
   // day presentation and interaction related props
   renderDay: PropTypes.func,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -47,6 +47,9 @@ export default {
   onNextMonthClick: PropTypes.func,
   onClose: PropTypes.func,
 
+  // month presentation and interaction related props
+  renderMonth: PropTypes.func,
+
   // day presentation and interaction related props
   renderDay: PropTypes.func,
   enableOutsideDays: PropTypes.bool,

--- a/src/utils/getVisibleDays.js
+++ b/src/utils/getVisibleDays.js
@@ -1,0 +1,49 @@
+import moment from 'moment';
+import toISOMonthString from './toISOMonthString';
+
+export default function getVisibleDays(month, numberOfMonths, enableOutsideDays) {
+  if (!moment.isMoment(month)) return {};
+
+  const visibleDaysByMonth = {};
+  let currentMonth = month.clone().subtract(1, 'month');
+  for (let i = 0; i < numberOfMonths + 2; i += 1) { // account for transition months
+    const visibleDays = [];
+
+    // set utc offset to get correct dates in future (when timezone changes)
+    const baseDate = currentMonth.clone();
+    const firstOfMonth = baseDate.clone().startOf('month').hour(12);
+    const lastOfMonth = baseDate.clone().endOf('month').hour(12);
+
+    const currentDay = firstOfMonth.clone();
+
+    // days belonging to the previous month
+    if (enableOutsideDays) {
+      for (let j = 0; j < currentDay.weekday(); j += 1) {
+        const prevDay = currentDay.clone().subtract(j + 1, 'day');
+        visibleDays.unshift(prevDay);
+      }
+    }
+
+    while (currentDay < lastOfMonth) {
+      visibleDays.push(currentDay.clone());
+      currentDay.add(1, 'day');
+    }
+
+    if (enableOutsideDays) {
+      // weekday() returns the index of the day of the week according to the locale
+      // this means if the week starts on Monday, weekday() will return 0 for a Monday date, not 1
+      if (currentDay.weekday() !== 0) {
+        // days belonging to the next month
+        for (let k = currentDay.weekday(), count = 0; k < 7; k += 1, count += 1) {
+          const nextDay = currentDay.clone().add(count, 'day');
+          visibleDays.push(nextDay);
+        }
+      }
+    }
+
+    visibleDaysByMonth[toISOMonthString(currentMonth)] = visibleDays;
+    currentMonth = currentMonth.clone().add(1, 'month');
+  }
+
+  return visibleDaysByMonth;
+}

--- a/src/utils/isAfterDay.js
+++ b/src/utils/isAfterDay.js
@@ -1,8 +1,9 @@
 import moment from 'moment';
 
 import isBeforeDay from './isBeforeDay';
+import isSameDay from './isSameDay';
 
-export default function isInclusivelyAfterDay(a, b) {
+export default function isAfterDay(a, b) {
   if (!moment.isMoment(a) || !moment.isMoment(b)) return false;
-  return !isBeforeDay(a, b);
+  return !isBeforeDay(a, b) && !isSameDay(a, b);
 }

--- a/src/utils/isBeforeDay.js
+++ b/src/utils/isBeforeDay.js
@@ -1,0 +1,18 @@
+import moment from 'moment';
+
+export default function isBeforeDay(a, b) {
+  if (!moment.isMoment(a) || !moment.isMoment(b)) return false;
+
+  const aYear = a.year();
+  const aMonth = a.month();
+
+  const bYear = b.year();
+  const bMonth = b.month();
+
+  const isSameYear = aYear === bYear;
+  const isSameMonth = aMonth === bMonth;
+
+  if (isSameYear && isSameMonth) return a.date() < b.date();
+  if (isSameYear) return aMonth < bMonth;
+  return aYear < bYear;
+}

--- a/src/utils/isDayVisible.js
+++ b/src/utils/isDayVisible.js
@@ -1,0 +1,12 @@
+import isBeforeDay from './isBeforeDay';
+import isAfterDay from './isAfterDay';
+
+export default function isDayVisible(day, month, numberOfMonths, enableOutsideDays) {
+  let firstDayOfFirstMonth = month.clone().startOf('month');
+  if (enableOutsideDays) firstDayOfFirstMonth = firstDayOfFirstMonth.startOf('week');
+  if (isBeforeDay(day, firstDayOfFirstMonth)) return false;
+
+  let lastDayOfLastMonth = month.clone().add(numberOfMonths - 1, 'months').endOf('month');
+  if (enableOutsideDays) lastDayOfLastMonth = lastDayOfLastMonth.endOf('week');
+  return !isAfterDay(day, lastDayOfLastMonth);
+}

--- a/src/utils/isInclusivelyBeforeDay.js
+++ b/src/utils/isInclusivelyBeforeDay.js
@@ -1,8 +1,8 @@
 import moment from 'moment';
 
-import isSameDay from './isSameDay';
+import isAfterDay from './isAfterDay';
 
 export default function isInclusivelyBeforeDay(a, b) {
   if (!moment.isMoment(a) || !moment.isMoment(b)) return false;
-  return a.isBefore(b) || isSameDay(a, b);
+  return !isAfterDay(a, b);
 }

--- a/src/utils/toISOMonthString.js
+++ b/src/utils/toISOMonthString.js
@@ -1,0 +1,12 @@
+import moment from 'moment';
+
+import toMomentObject from './toMomentObject';
+
+import { ISO_MONTH_FORMAT } from '../../constants';
+
+export default function toISOMonthString(date, currentFormat) {
+  const dateObj = moment.isMoment(date) ? date : toMomentObject(date, currentFormat);
+  if (!dateObj) return null;
+
+  return dateObj.format(ISO_MONTH_FORMAT);
+}

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import moment from 'moment';
+import momentJalaali from 'moment-jalaali';
 import { storiesOf } from '@kadira/storybook';
 
 import DateRangePickerWrapper from '../examples/DateRangePickerWrapper';
@@ -75,6 +76,16 @@ storiesOf('DateRangePicker (DRP)', module)
           closeDatePicker: '关闭',
           clearDates: '清除日期',
         }}
+      />
+    );
+  })
+  .addWithInfo('non-english locale (Persian)', () => {
+    moment.locale('fa');
+    return (
+      <DateRangePickerWrapper
+        placeholder="تقویم فارسی"
+        renderMonth={month => momentJalaali(month).format('jMMMM jYYYY')}
+        renderDay={day => momentJalaali(day).format('jD')}
       />
     );
   });

--- a/stories/DateRangePicker_calendar.js
+++ b/stories/DateRangePicker_calendar.js
@@ -129,4 +129,10 @@ storiesOf('DRP - Calendar Props', module)
       )}
       autoFocus
     />
+  ))
+  .addWithInfo('with keyboard shorcuts panel hidden', () => (
+    <DateRangePickerWrapper
+      hideKeyboardShortcutsPanel
+      autoFocus
+    />
   ));

--- a/stories/DateRangePicker_calendar.js
+++ b/stories/DateRangePicker_calendar.js
@@ -135,4 +135,26 @@ storiesOf('DRP - Calendar Props', module)
       hideKeyboardShortcutsPanel
       autoFocus
     />
+  ))
+  .addWithInfo('with RTL support (and anchor right)', () => (
+    <div style={{ float: 'right' }}>
+      <DateRangePickerWrapper
+        anchorDirection={ANCHOR_RIGHT}
+        isRTL
+        autoFocus
+      />
+    </div>
+  ))
+  .addWithInfo('vertical with RTL support', () => (
+    <DateRangePickerWrapper
+      isRTL={true}
+      orientation={VERTICAL_ORIENTATION}
+      autoFocus
+    />
+  ))
+  .addWithInfo('with keyboard shorcuts panel hidden', () => (
+    <DateRangePickerWrapper
+      hideKeyboardShortcutsPanel
+      autoFocus
+    />
   ));

--- a/stories/DateRangePicker_calendar.js
+++ b/stories/DateRangePicker_calendar.js
@@ -118,7 +118,7 @@ storiesOf('DRP - Calendar Props', module)
   ))
   .addWithInfo('with month specified on open', () => (
     <DateRangePickerWrapper
-      initialVisibleMonth={() => moment('04 2017', 'MM YYYY')}
+      initialVisibleMonth={() => moment().add(10, 'months')}
       autoFocus
     />
   ))

--- a/stories/DateRangePicker_calendar.js
+++ b/stories/DateRangePicker_calendar.js
@@ -136,6 +136,12 @@ storiesOf('DRP - Calendar Props', module)
       autoFocus
     />
   ))
+  .addWithInfo('with keyboard shorcuts panel hidden', () => (
+    <DateRangePickerWrapper
+      hideKeyboardShortcutsPanel
+      autoFocus
+    />
+  ))
   .addWithInfo('with RTL support (and anchor right)', () => (
     <div style={{ float: 'right' }}>
       <DateRangePickerWrapper
@@ -147,14 +153,8 @@ storiesOf('DRP - Calendar Props', module)
   ))
   .addWithInfo('vertical with RTL support', () => (
     <DateRangePickerWrapper
-      isRTL={true}
       orientation={VERTICAL_ORIENTATION}
-      autoFocus
-    />
-  ))
-  .addWithInfo('with keyboard shorcuts panel hidden', () => (
-    <DateRangePickerWrapper
-      hideKeyboardShortcutsPanel
+      isRTL
       autoFocus
     />
   ));

--- a/stories/DateRangePicker_input.js
+++ b/stories/DateRangePicker_input.js
@@ -105,9 +105,4 @@ storiesOf('DRP - Input Props', module)
       initialEndDate={moment().add(10, 'days')}
       screenReaderInputMessage="Here you could inform screen reader users of the date format, minimum nights, blocked out dates, etc"
     />
-  ))
-  .addWithInfo('with RTL support', () => (
-    <DateRangePickerWrapper
-      isRTL={true}
-    />
   ));

--- a/stories/DateRangePicker_input.js
+++ b/stories/DateRangePicker_input.js
@@ -105,4 +105,9 @@ storiesOf('DRP - Input Props', module)
       initialEndDate={moment().add(10, 'days')}
       screenReaderInputMessage="Here you could inform screen reader users of the date format, minimum nights, blocked out dates, etc"
     />
+  ))
+  .addWithInfo('with RTL support', () => (
+    <DateRangePickerWrapper
+      isRTL={true}
+    />
   ));

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -24,9 +24,6 @@ storiesOf('SingleDatePicker (SDP)', module)
   .addWithInfo('default', () => (
     <SingleDatePickerWrapper />
   ))
-  .addWithInfo('with RTL support', () => (
-    <SingleDatePickerWrapper isRTL />
-  ))
   .addWithInfo('as part of a form', () => (
     <div>
       <SingleDatePickerWrapper />

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -46,14 +46,13 @@ storiesOf('SingleDatePicker (SDP)', module)
       />
     );
   })
-    .addWithInfo('non-english locale (Persian)', () => {
-        moment.locale('fa');
-        // if (moment.locale().toString() === "fa") momentJalaali.loadPersian();
-        return (
-            <SingleDatePickerWrapper
-                placeholder="تقویم فارسی"
-                renderMonth = {(month) => momentJalaali(month).format("jMMMM jYYYY")}
-                renderDay= {(day) => momentJalaali(day).format("jD")}
-            />
-        );
-    });
+  .addWithInfo('non-english locale (Persian)', () => {
+    moment.locale('fa');
+    return (
+      <SingleDatePickerWrapper
+        placeholder="تقویم فارسی"
+        renderMonth={month => momentJalaali(month).format('jMMMM jYYYY')}
+        renderDay={day => momentJalaali(day).format('jD')}
+      />
+    );
+  });

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -24,6 +24,9 @@ storiesOf('SingleDatePicker (SDP)', module)
   .addWithInfo('default', () => (
     <SingleDatePickerWrapper />
   ))
+  .addWithInfo('with RTL support', () => (
+    <SingleDatePickerWrapper isRTL />
+  ))
   .addWithInfo('as part of a form', () => (
     <div>
       <SingleDatePickerWrapper />

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import moment from 'moment';
+import momentJalaali from 'moment-jalaali';
 import { storiesOf } from '@kadira/storybook';
 
 import SingleDatePickerWrapper from '../examples/SingleDatePickerWrapper';
@@ -44,4 +45,15 @@ storiesOf('SingleDatePicker (SDP)', module)
         }}
       />
     );
-  });
+  })
+    .addWithInfo('non-english locale (Persian)', () => {
+        moment.locale('fa');
+        // if (moment.locale().toString() === "fa") momentJalaali.loadPersian();
+        return (
+            <SingleDatePickerWrapper
+                placeholder="تقویم فارسی"
+                renderMonth = {(month) => momentJalaali(month).format("jMMMM jYYYY")}
+                renderDay= {(day) => momentJalaali(day).format("jD")}
+            />
+        );
+    });

--- a/stories/SingleDatePicker_calendar.js
+++ b/stories/SingleDatePicker_calendar.js
@@ -126,4 +126,10 @@ storiesOf('SDP - Calendar Props', module)
       hideKeyboardShortcutsPanel
       autoFocus
     />
+  ))
+  .addWithInfo('with RTL support', () => (
+    <SingleDatePickerWrapper
+      isRTL
+      autoFocus
+    />
   ));

--- a/stories/SingleDatePicker_calendar.js
+++ b/stories/SingleDatePicker_calendar.js
@@ -120,4 +120,10 @@ storiesOf('SDP - Calendar Props', module)
       )}
       autoFocus
     />
+  ))
+  .addWithInfo('with keyboard shorcuts panel hidden', () => (
+    <SingleDatePickerWrapper
+      hideKeyboardShortcutsPanel
+      autoFocus
+    />
   ));

--- a/stories/SingleDatePicker_calendar.js
+++ b/stories/SingleDatePicker_calendar.js
@@ -95,7 +95,7 @@ storiesOf('SDP - Calendar Props', module)
   ))
   .addWithInfo('with month specified on open', () => (
     <SingleDatePickerWrapper
-      initialVisibleMonth={() => moment('01 2017', 'MM YYYY')}
+      initialVisibleMonth={() => moment().add(10, 'months')}
       autoFocus
     />
   ))

--- a/test/components/CalendarDay_spec.jsx
+++ b/test/components/CalendarDay_spec.jsx
@@ -4,7 +4,7 @@ import sinon from 'sinon-sandbox';
 import { shallow } from 'enzyme';
 import moment from 'moment';
 
-import CalendarDay, { getModifiersForDay } from '../../src/components/CalendarDay';
+import CalendarDay from '../../src/components/CalendarDay';
 
 describe('CalendarDay', () => {
   describe('#render', () => {
@@ -120,35 +120,6 @@ describe('CalendarDay', () => {
       const wrapper = shallow(<CalendarDay onDayMouseLeave={onMouseLeaveStub} />);
       wrapper.instance().onDayMouseLeave();
       expect(onMouseLeaveStub).to.have.property('callCount', 1);
-    });
-  });
-
-  describe('#getModifiersForDay', () => {
-    it('returns empty array if day is not passed in', () => {
-      const modifierKey = 'foo';
-      const modifiers = {};
-      modifiers[modifierKey] = () => true;
-
-      const filteredModifiers = getModifiersForDay(modifiers);
-      expect(filteredModifiers).to.have.lengthOf(0);
-    });
-
-    it('returns key for true modifier', () => {
-      const modifierKey = 'foo';
-      const modifiers = {};
-      modifiers[modifierKey] = () => true;
-
-      const filteredModifiers = getModifiersForDay(modifiers, moment());
-      expect(filteredModifiers).to.include(modifierKey);
-    });
-
-    it('does not return key for false modifier', () => {
-      const modifierKey = 'foo';
-      const modifiers = {};
-      modifiers[modifierKey] = () => false;
-
-      const filteredModifiers = getModifiersForDay(modifiers, moment());
-      expect(filteredModifiers).not.to.include(modifierKey);
     });
   });
 });

--- a/test/components/DateRangePickerInput_spec.jsx
+++ b/test/components/DateRangePickerInput_spec.jsx
@@ -13,6 +13,11 @@ describe('DateRangePickerInput', () => {
       expect(wrapper.is('.DateRangePickerInput')).to.equal(true);
     });
 
+    it('is .DateRangePickerInput--rtl class', () => {
+      const wrapper = shallow(<DateRangePickerInput isRTL />);
+      expect(wrapper.is('.DateRangePickerInput--rtl')).to.equal(true);
+    });
+
     it('renders 2 <DateInput /> components', () => {
       const wrapper = shallow(<DateRangePickerInput />);
       expect(wrapper.find(DateInput)).to.have.lengthOf(2);

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -30,6 +30,11 @@ describe('DateRangePicker', () => {
       expect(wrapper.find('.DateRangePicker__picker')).to.have.length(1);
     });
 
+    it('renders .DateRangePicker__picker--rtl class', () => {
+      const wrapper = shallow(<DateRangePicker focusedInput={START_DATE} isRTL />);
+      expect(wrapper.find('.DateRangePicker__picker--rtl')).to.have.length(1);
+    });
+
     it('renders <DateRangePickerInputWithHandlers />', () => {
       const wrapper = shallow(<DateRangePicker focusedInput={START_DATE} />);
       expect(wrapper.find(DateRangePickerInputController)).to.have.length(1);

--- a/test/components/DayPickerNavigation_spec.jsx
+++ b/test/components/DayPickerNavigation_spec.jsx
@@ -33,6 +33,11 @@ describe('DayPickerNavigation', () => {
         expect(wrapper.find('.DayPickerNavigation__prev')).to.have.lengthOf(1);
       });
 
+      it('has .DayPickerNavigation__prev--rtl class', () => {
+        const wrapper = shallow(<DayPickerNavigation isRTL />);
+        expect(wrapper.find('.DayPickerNavigation__prev--rtl')).to.have.lengthOf(1);
+      });
+
       it('has .DayPickerNavigation__prev on custom icon', () => {
         const wrapper = shallow(<DayPickerNavigation navPrev={<span>Prev</span>} />);
         expect(wrapper.find('.DayPickerNavigation__prev')).to.have.lengthOf(1);
@@ -58,6 +63,11 @@ describe('DayPickerNavigation', () => {
       it('.DayPickerNavigation__next class exists', () => {
         const wrapper = shallow(<DayPickerNavigation />);
         expect(wrapper.find('.DayPickerNavigation__next')).to.have.lengthOf(1);
+      });
+
+      it('.DayPickerNavigation__next--rtl class exists', () => {
+        const wrapper = shallow(<DayPickerNavigation isRTL />);
+        expect(wrapper.find('.DayPickerNavigation__next--rtl')).to.have.lengthOf(1);
       });
 
       it('has .DayPickerNavigation__next class on custom icon', () => {

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -55,6 +55,14 @@ describe('DayPicker', () => {
           expect(wrapper.find('.DayPicker__week-header')).to.have.lengthOf(1);
         });
       });
+
+      describe('props.isRTL === true', () => {
+        it('has .DayPicker__week-header--rtl element', () => {
+          const wrapper = shallow(<DayPicker isRTL />);
+          const firstChildOf = wrapper.find('.DayPicker__week-header--rtl').first();
+          expect(firstChildOf.is('.DayPicker__week-header--rtl')).to.equal(true);
+        });
+      });
     });
 
     describe('transitionContainer', () => {

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -6,6 +6,8 @@ import sinon from 'sinon-sandbox';
 import { mount, shallow } from 'enzyme';
 import wrap from 'mocha-wrap';
 
+import * as isDayVisible from '../../src/utils/isDayVisible';
+
 import DayPicker, { calculateDimension } from '../../src/components/DayPicker';
 import CalendarMonthGrid from '../../src/components/CalendarMonthGrid';
 import DayPickerNavigation from '../../src/components/DayPickerNavigation';
@@ -457,13 +459,6 @@ describe('DayPicker', () => {
       translateFirstDayPickerForAnimationSpy = sinon.stub(DayPicker.prototype, 'translateFirstDayPickerForAnimation');
     });
 
-    it('calls props.onPrevMonthClick', () => {
-      const onPrevMonthClickSpy = sinon.stub();
-      const wrapper = shallow(<DayPicker onPrevMonthClick={onPrevMonthClickSpy} />);
-      wrapper.instance().onPrevMonthClick(event);
-      expect(onPrevMonthClickSpy).to.have.property('callCount', 1);
-    });
-
     it('calls translateFirstDayPickerForAnimation', () => {
       const wrapper = shallow(<DayPicker />);
       wrapper.instance().onPrevMonthClick(event);
@@ -485,13 +480,6 @@ describe('DayPicker', () => {
   });
 
   describe('#onNextMonthClick', () => {
-    it('calls props.onNextMonthClick', () => {
-      const onNextMonthClickSpy = sinon.stub();
-      const wrapper = shallow(<DayPicker onNextMonthClick={onNextMonthClickSpy} />);
-      wrapper.instance().onNextMonthClick(event);
-      expect(onNextMonthClickSpy).to.have.property('callCount', 1);
-    });
-
     it('sets state.monthTransition to "next"', () => {
       const wrapper = shallow(<DayPicker />);
       wrapper.instance().onNextMonthClick();
@@ -535,7 +523,7 @@ describe('DayPicker', () => {
       it('returns first day of arg if getFirstFocusableDay returns invisible day', () => {
         const test = moment().add(3, 'months');
         const getFirstFocusableDayStub = sinon.stub().returns(today);
-        sinon.stub(DayPicker.prototype, 'isDayVisible').returns(false);
+        sinon.stub(isDayVisible, 'default').returns(false);
         const wrapper = shallow(<DayPicker getFirstFocusableDay={getFirstFocusableDayStub} />);
         expect(wrapper.instance().getFocusedDay(test).isSame(test.startOf('month'), 'day')).to.equal(true);
       });
@@ -578,7 +566,7 @@ describe('DayPicker', () => {
       describe('arg is visible', () => {
         it('does not call `onNextMonthClick`', () => {
           const onNextMonthClickSpy = sinon.spy(DayPicker.prototype, 'onNextMonthClick');
-          sinon.stub(DayPicker.prototype, 'isDayVisible').returns(true);
+          sinon.stub(isDayVisible, 'default').returns(true);
           const nextMonth = moment().add(1, 'month');
           const wrapper = shallow(<DayPicker />);
           wrapper.state().focusedDate = nextMonth;
@@ -587,7 +575,7 @@ describe('DayPicker', () => {
         });
 
         it('returns false', () => {
-          sinon.stub(DayPicker.prototype, 'isDayVisible').returns(true);
+          sinon.stub(isDayVisible, 'default').returns(true);
           const nextMonth = moment().add(1, 'month');
           const wrapper = shallow(<DayPicker />);
           wrapper.state().focusedDate = nextMonth;
@@ -598,7 +586,7 @@ describe('DayPicker', () => {
       describe('arg is not visible', () => {
         it('calls `onNextMonthClick`', () => {
           const onNextMonthClickSpy = sinon.spy(DayPicker.prototype, 'onNextMonthClick');
-          sinon.stub(DayPicker.prototype, 'isDayVisible').returns(false);
+          sinon.stub(isDayVisible, 'default').returns(false);
           const nextMonth = moment().add(1, 'month');
           const wrapper = shallow(<DayPicker />);
           wrapper.state().focusedDate = nextMonth;
@@ -607,7 +595,7 @@ describe('DayPicker', () => {
         });
 
         it('returns true', () => {
-          sinon.stub(DayPicker.prototype, 'isDayVisible').returns(false);
+          sinon.stub(isDayVisible, 'default').returns(false);
           const nextMonth = moment().add(1, 'month');
           const wrapper = shallow(<DayPicker />);
           wrapper.state().focusedDate = nextMonth;
@@ -640,7 +628,7 @@ describe('DayPicker', () => {
       describe('arg is visible', () => {
         it('does not call `onPrevMonthClick`', () => {
           const onPrevMonthClickSpy = sinon.spy(DayPicker.prototype, 'onPrevMonthClick');
-          sinon.stub(DayPicker.prototype, 'isDayVisible').returns(true);
+          sinon.stub(isDayVisible, 'default').returns(true);
           const nextMonth = moment().add(1, 'month');
           const wrapper = shallow(<DayPicker />);
           wrapper.state().focusedDate = nextMonth;
@@ -649,7 +637,7 @@ describe('DayPicker', () => {
         });
 
         it('returns false', () => {
-          sinon.stub(DayPicker.prototype, 'isDayVisible').returns(true);
+          sinon.stub(isDayVisible, 'default').returns(true);
           const nextMonth = moment().add(1, 'month');
           const wrapper = shallow(<DayPicker />);
           wrapper.state().focusedDate = nextMonth;
@@ -664,7 +652,7 @@ describe('DayPicker', () => {
 
         it('calls `onPrevMonthClick`', () => {
           const onPrevMonthClickSpy = sinon.spy(DayPicker.prototype, 'onPrevMonthClick');
-          sinon.stub(DayPicker.prototype, 'isDayVisible').returns(false);
+          sinon.stub(isDayVisible, 'default').returns(false);
           const nextMonth = moment().add(1, 'month');
           const wrapper = shallow(<DayPicker />);
           wrapper.state().focusedDate = nextMonth;
@@ -673,7 +661,7 @@ describe('DayPicker', () => {
         });
 
         it('returns true', () => {
-          sinon.stub(DayPicker.prototype, 'isDayVisible').returns(false);
+          sinon.stub(isDayVisible, 'default').returns(false);
           const nextMonth = moment().add(1, 'month');
           const wrapper = shallow(<DayPicker />);
           wrapper.state().focusedDate = nextMonth;
@@ -694,37 +682,6 @@ describe('DayPicker', () => {
       const wrapper = shallow(<DayPicker />);
       wrapper.instance().multiplyScrollableMonths();
       expect(wrapper.state().scrollableMonthMultiple).to.equal(2);
-    });
-  });
-
-  describe('#isDayVisible', () => {
-    it('returns true if arg is in visible months', () => {
-      const test = moment().add(3, 'months');
-      const wrapper = shallow(<DayPicker numberOfMonths={1} />);
-      wrapper.setState({
-        currentMonth: moment().add(3, 'months'),
-      });
-
-      expect(wrapper.instance().isDayVisible(test)).to.equal(true);
-    });
-
-    it('returns false if arg is before first month', () => {
-      const wrapper = shallow(<DayPicker numberOfMonths={1} />);
-      wrapper.setState({
-        currentMonth: moment().add(3, 'months'),
-      });
-
-      expect(wrapper.instance().isDayVisible(today)).to.equal(false);
-    });
-
-    it('returns false if arg is after last month', () => {
-      const test = moment().add(4, 'months');
-      const wrapper = shallow(<DayPicker numberOfMonths={1} />);
-      wrapper.setState({
-        currentMonth: moment().add(3, 'months'),
-      });
-
-      expect(wrapper.instance().isDayVisible(test)).to.equal(false);
     });
   });
 

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -114,8 +114,8 @@ describe('DayPicker', () => {
     });
 
     describe('DayPickerKeyboardShortcuts', () => {
-      it('component exists if state.isTouchDevice is false', () => {
-        const wrapper = shallow(<DayPicker />);
+      it('component exists if state.isTouchDevice is false and hideKeyboardShortcutsPanel is false', () => {
+        const wrapper = shallow(<DayPicker hideKeyboardShortcutsPanel={false} />);
         wrapper.setState({ isTouchDevice: false });
         expect(wrapper.find(DayPickerKeyboardShortcuts)).to.have.lengthOf(1);
       });
@@ -123,6 +123,11 @@ describe('DayPicker', () => {
       it('component does not exist if isTouchDevice() is true', () => {
         const wrapper = shallow(<DayPicker />);
         wrapper.setState({ isTouchDevice: true });
+        expect(wrapper.find(DayPickerKeyboardShortcuts)).to.have.lengthOf(0);
+      });
+
+      it('component does not exist if hideKeyboardShortcutsPanel is true', () => {
+        const wrapper = shallow(<DayPicker hideKeyboardShortcutsPanel />);
         expect(wrapper.find(DayPickerKeyboardShortcuts)).to.have.lengthOf(0);
       });
     });

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -55,14 +55,6 @@ describe('DayPicker', () => {
           expect(wrapper.find('.DayPicker__week-header')).to.have.lengthOf(1);
         });
       });
-
-      describe('props.isRTL === true', () => {
-        it('has .DayPicker__week-header--rtl element', () => {
-          const wrapper = shallow(<DayPicker isRTL />);
-          const firstChildOf = wrapper.find('.DayPicker__week-header--rtl').first();
-          expect(firstChildOf.is('.DayPicker__week-header--rtl')).to.equal(true);
-        });
-      });
     });
 
     describe('transitionContainer', () => {

--- a/test/components/SingleDatePickerInput_spec.jsx
+++ b/test/components/SingleDatePickerInput_spec.jsx
@@ -11,6 +11,11 @@ describe('SingleDatePickerInput', () => {
       const wrapper = shallow(<SingleDatePickerInput id="date" />);
       expect(wrapper.is('.SingleDatePickerInput')).to.equal(true);
     });
+
+    it('is .SingleDatePickerInput--rtl class', () => {
+      const wrapper = shallow(<SingleDatePickerInput id="date" isRTL />);
+      expect(wrapper.is('.SingleDatePickerInput--rtl')).to.equal(true);
+    });
   });
 
   describe('clear date', () => {

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -76,6 +76,19 @@ describe('SingleDatePicker', () => {
         expect(wrapper.find('.SingleDatePicker__picker')).to.have.lengthOf(1);
       });
 
+      it('has .SingleDatePicker__picker--rtl class', () => {
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+            focused
+            isRTL
+          />,
+        );
+        expect(wrapper.find('.SingleDatePicker__picker--rtl')).to.have.lengthOf(1);
+      });
+
       describe('props.focused === false', () => {
         it('does not render a <DayPicker>', () => {
           const wrapper = shallow(

--- a/test/utils/getVisibleDays_spec.js
+++ b/test/utils/getVisibleDays_spec.js
@@ -1,0 +1,34 @@
+import moment from 'moment';
+import { expect } from 'chai';
+
+import isSameDay from '../../src/utils/isSameDay';
+import getVisibleDays from '../../src/utils/getVisibleDays';
+
+const today = moment();
+
+describe('getVisibleDays', () => {
+  it('has numberOfMonths entries', () => {
+    const numberOfMonths = 3;
+    const visibleDays = getVisibleDays(today, numberOfMonths, false);
+    expect(Object.keys(visibleDays).length).to.equal(numberOfMonths + 2);
+  });
+
+  it('values are all arrays of moment objects', () => {
+    const visibleDays = getVisibleDays(today, 3, false);
+    Object.values(visibleDays).forEach((days) => {
+      expect(Array.isArray(days)).to.equal(true);
+      days.forEach((day) => {
+        expect(moment.isMoment(day)).to.equal(true);
+      });
+    });
+  });
+
+  it('contains first arg day', () => {
+    const visibleDays = getVisibleDays(today, 3, false);
+    const containsToday = Object.values(visibleDays).filter(
+      days => days.filter(day => isSameDay(day, today)).length > 0,
+    );
+    expect(containsToday.length > 0).to.equal(true);
+  });
+});
+

--- a/test/utils/isAfterDay_spec.js
+++ b/test/utils/isAfterDay_spec.js
@@ -1,0 +1,39 @@
+import moment from 'moment';
+import { expect } from 'chai';
+
+import isAfterDay from '../../src/utils/isAfterDay';
+
+const today = moment();
+const tomorrow = moment().add(1, 'days');
+
+describe('isAfterDay', () => {
+  it('returns true if first arg is after the second but have same month and year', () => {
+    expect(isAfterDay(tomorrow, today)).to.equal(true);
+  });
+
+  it('returns true if first arg is after the second but have same day and year', () => {
+    expect(isAfterDay(moment().clone().add(1, 'month'), today)).to.equal(true);
+  });
+
+  it('returns true if first arg is after the second but have same day and month', () => {
+    expect(isAfterDay(moment().clone().add(1, 'year'), today)).to.equal(true);
+  });
+
+  it('returns false if args are the same day', () => {
+    expect(isAfterDay(today, today)).to.equal(false);
+  });
+
+  it('returns false if first arg is after the second', () => {
+    expect(isAfterDay(today, tomorrow)).to.equal(false);
+  });
+
+  describe('non-moment object arguments', () => {
+    it('is false if first argument is not a moment object', () => {
+      expect(isAfterDay(null, today)).to.equal(false);
+    });
+
+    it('is false if second argument is not a moment object', () => {
+      expect(isAfterDay(today, 'foo')).to.equal(false);
+    });
+  });
+});

--- a/test/utils/isBeforeDay_spec.js
+++ b/test/utils/isBeforeDay_spec.js
@@ -1,0 +1,39 @@
+import moment from 'moment';
+import { expect } from 'chai';
+
+import isBeforeDay from '../../src/utils/isBeforeDay';
+
+const today = moment();
+const tomorrow = moment().add(1, 'days');
+
+describe('isBeforeDay', () => {
+  it('returns true if first arg is before the second but have same month and year', () => {
+    expect(isBeforeDay(today, tomorrow)).to.equal(true);
+  });
+
+  it('returns true if first arg is before the second but have same day and year', () => {
+    expect(isBeforeDay(today, moment().clone().add(1, 'month'))).to.equal(true);
+  });
+
+  it('returns true if first arg is before the second but have same day and month', () => {
+    expect(isBeforeDay(today, moment().clone().add(1, 'year'))).to.equal(true);
+  });
+
+  it('returns false if args are the same day', () => {
+    expect(isBeforeDay(today, today)).to.equal(false);
+  });
+
+  it('returns false if first arg is after the second', () => {
+    expect(isBeforeDay(tomorrow, today)).to.equal(false);
+  });
+
+  describe('non-moment object arguments', () => {
+    it('is false if first argument is not a moment object', () => {
+      expect(isBeforeDay(null, today)).to.equal(false);
+    });
+
+    it('is false if second argument is not a moment object', () => {
+      expect(isBeforeDay(today, 'foo')).to.equal(false);
+    });
+  });
+});

--- a/test/utils/isDayVisible_spec.js
+++ b/test/utils/isDayVisible_spec.js
@@ -1,0 +1,24 @@
+import moment from 'moment';
+import { expect } from 'chai';
+
+import isDayVisible from '../../src/utils/isDayVisible';
+
+describe('#isDayVisible', () => {
+  it('returns true if arg is in visible months', () => {
+    const test = moment().add(3, 'months');
+    const currentMonth = moment().add(2, 'months');
+    expect(isDayVisible(test, currentMonth, 2)).to.equal(true);
+  });
+
+  it('returns false if arg is before first month', () => {
+    const test = moment().add(1, 'months');
+    const currentMonth = moment().add(2, 'months');
+    expect(isDayVisible(test, currentMonth, 2)).to.equal(false);
+  });
+
+  it('returns false if arg is after last month', () => {
+    const test = moment().add(4, 'months');
+    const currentMonth = moment().add(2, 'months');
+    expect(isDayVisible(test, currentMonth, 2)).to.equal(false);
+  });
+});

--- a/test/utils/toISOMonthString_spec.js
+++ b/test/utils/toISOMonthString_spec.js
@@ -1,0 +1,49 @@
+import moment from 'moment';
+import { expect } from 'chai';
+
+import { ISO_FORMAT, ISO_MONTH_FORMAT } from '../../constants';
+import toISOMonthString from '../../src/utils/toISOMonthString';
+
+describe('#toISOMonthString', () => {
+  describe('arg is a moment object', () => {
+    it('returns month in ISO_MONTH_FORMAT format', () => {
+      const today = moment();
+      expect(toISOMonthString(today)).to.equal(today.format(ISO_MONTH_FORMAT));
+    });
+  });
+
+  describe('arg is a string', () => {
+    describe('arg is in ISO format', () => {
+      it('returns month in ISO_MONTH_FORMAT format', () => {
+        const today = moment();
+        const todayISO = today.format(ISO_FORMAT);
+        expect(toISOMonthString(todayISO)).to.equal(today.format(ISO_MONTH_FORMAT));
+      });
+    });
+
+    describe('arg matches the second arg date format provided', () => {
+      it('returns month in ISO_MONTH_FORMAT format', () => {
+        const today = moment();
+        const dateFormat = 'MM_DD_YYYY';
+        const formattedDate = today.format(dateFormat);
+        const monthString = toISOMonthString(formattedDate, dateFormat);
+        expect(monthString).to.equal(today.format(ISO_MONTH_FORMAT));
+      });
+    });
+
+    describe('arg is neither in iso format or in the provided format', () => {
+      it('returns null', () => {
+        const today = moment();
+        const dateFormat = 'MM_DD_YYYY';
+        const formattedDate = today.format('MM-DD-YYYY');
+        expect(toISOMonthString(formattedDate, dateFormat)).to.equal(null);
+      });
+    });
+
+    describe('arg is not a valid date string', () => {
+      it('returns null', () => {
+        expect(toISOMonthString('This is not a date')).to.equal(null);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adresses #479.

Usefull for DatePicker "resetting" focusedInput when clicking outside of the component.
It avoids DatePicker from showing hover style on day when hovered if the DayPicker does not have 
focus.
